### PR TITLE
FIBO-148 (WIP)

### DIFF
--- a/auto/src/components/VisNetwork.vue
+++ b/auto/src/components/VisNetwork.vue
@@ -60,8 +60,8 @@ export default {
   props: ['data'],
   mounted() {
     if (this.data) {
-      const nodes = new vis.DataSet(JSON.parse(this.data.nodes));
-      const edges = new vis.DataSet(JSON.parse(this.data.edges));
+      const nodes = new vis.DataSet(this.data.nodes);
+      const edges = new vis.DataSet(this.data.edges);
 
       const container = document.getElementById('ontograph');
       const edgeFilters = document.getElementsByName('edgesFilter');

--- a/auto/src/components/chunks/DIRECT_SUBCLASSES.vue
+++ b/auto/src/components/chunks/DIRECT_SUBCLASSES.vue
@@ -15,7 +15,7 @@ export default {
   props: ['value', 'entityMaping'],
   computed: {
     processedHtml() {
-      const html = `<customLink name="${this.value.valueA}" query="${this.value.valueB}"></customLink>`;
+      const html = `<customLink name="${this.value.label}" query="${this.value.iri}"></customLink>`;
       return {
         template: `<div>${html}</div>`,
       };

--- a/auto/src/components/chunks/INSTANCES.vue
+++ b/auto/src/components/chunks/INSTANCES.vue
@@ -15,7 +15,7 @@ export default {
   props: ['value', 'entityMaping'],
   computed: {
     processedHtml() {
-      const html = `<customLink name="${this.value.valueA}" query="${this.value.valueB}"></customLink>`;
+      const html = `<customLink name="${this.value.label}" query="${this.value.iri}"></customLink>`;
       return {
         template: `<div>${html}</div>`,
       };

--- a/auto/src/components/chunks/MODULES.vue
+++ b/auto/src/components/chunks/MODULES.vue
@@ -15,7 +15,7 @@ export default {
   props: ['value', 'entityMaping'],
   computed: {
     processedHtml() {
-      const html = `<customLink name="${this.value.valueA}" query="${this.value.valueB}"></customLink>`;
+      const html = `<customLink name="${this.value.label}" query="${this.value.iri}"></customLink>`;
       return {
         template: `<div>${html}</div>`,
       };

--- a/auto/src/store/index.js
+++ b/auto/src/store/index.js
@@ -7,8 +7,8 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    ontologyDefaultDomain: '/api/search',
-    modulesDefaultDomain: '/api/module',
+    ontologyDefaultDomain: '/auto/ontology/api/search',
+    modulesDefaultDomain: '/auto/ontology/api/module',
   },
   mutations: {
 

--- a/auto/src/store/index.js
+++ b/auto/src/store/index.js
@@ -7,8 +7,8 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    ontologyDefaultDomain: '/auto/search/json',
-    modulesDefaultDomain: '/auto/module/json',
+    ontologyDefaultDomain: '/api/search',
+    modulesDefaultDomain: '/api/module',
   },
   mutations: {
 

--- a/auto/src/views/Ontology.vue
+++ b/auto/src/views/Ontology.vue
@@ -114,9 +114,9 @@
                     <button v-clipboard="data.qName.replace('QName: ', '')" type="button" class="btn btn-sm btn-outline-primary">Copy</button>
                   </h6>
                   <span v-if="data.taxonomy && data.taxonomy.value">
-                    <p v-for="taxonomy in data.taxonomy.value" :key="taxonomy" class="taxonomy">
-                      <span v-for="(element,index) in taxonomy" :key="element">
-                        <customLink :name="element.valueA.value" :query="element.valueB.value"></customLink>
+                    <p v-for="(taxonomy, tIndex) in data.taxonomy.value" :key="'taxonomyParagraph'+tIndex" class="taxonomy">
+                      <span v-for="(element,index) in taxonomy" :key="'taxonomyEl'+tIndex+element.iri">
+                        <customLink :name="element.label" :query="element.iri"></customLink>
                         <span
                           class="card-subtitle mb-2 text-muted"
                           v-if="index != Object.keys(taxonomy).length - 1"

--- a/auto/src/views/Ontology.vue
+++ b/auto/src/views/Ontology.vue
@@ -473,7 +473,7 @@ export default {
 
       this.searchBox.isLoading = true
       try {
-        const result = await getHint(query, '/auto/hint');
+        const result = await getHint(query, '/api/hint');
         const hints = await result.json();
         hints.forEach(el => {
           el.labelForInternalSearch = el.label + " "; //this is hacky to make it possible to search text (add tag) the same as the label in hint results

--- a/auto/src/views/Ontology.vue
+++ b/auto/src/views/Ontology.vue
@@ -109,7 +109,7 @@
                     {{data.iri}}
                     <button v-clipboard="data.iri" type="button" class="btn btn-sm btn-outline-primary">Copy</button>
                   </h6>
-                  <h6 class="card-subtitle mb-2 text-muted" v-if="data.qName">
+                  <h6 class="card-subtitle mb-2 text-muted" v-if="data.qName && data.qName !== ''">
                     {{data.qName}}
                     <button v-clipboard="data.qName.replace('QName: ', '')" type="button" class="btn btn-sm btn-outline-primary">Copy</button>
                   </h6>

--- a/auto/src/views/Ontology.vue
+++ b/auto/src/views/Ontology.vue
@@ -473,7 +473,7 @@ export default {
 
       this.searchBox.isLoading = true
       try {
-        const result = await getHint(query, '/api/hint');
+        const result = await getHint(query, '/auto/ontology/api/hint');
         const hints = await result.json();
         hints.forEach(el => {
           el.labelForInternalSearch = el.label + " "; //this is hacky to make it possible to search text (add tag) the same as the label in hint results

--- a/auto/vue.config.js
+++ b/auto/vue.config.js
@@ -17,21 +17,21 @@ module.exports = {
   runtimeCompiler: true,
   devServer: {
     proxy: {
-      '^/api/search$': {
+      '^/auto/ontology/api/search$': {
         target: 'http://auto-viewer.spec.edmcouncil.org',
         // changeOrigin: true,
         // secure:false,
         // pathRewrite: {'^/auto': '/'},
         //logLevel: 'debug'
       },
-      '^/api/module$': {
+      '^/auto/ontology/api/module$': {
         target: 'http://auto-viewer.spec.edmcouncil.org',
         // changeOrigin: true,
         // secure:false,
         // pathRewrite: {'^/auto': '/'},
         //logLevel: 'debug'
       },
-      '^/api/hint': {
+      '^/auto/ontology/api/hint': {
         target: 'http://auto-viewer.spec.edmcouncil.org',
         // changeOrigin: true,
         // secure:false,

--- a/auto/vue.config.js
+++ b/auto/vue.config.js
@@ -17,25 +17,25 @@ module.exports = {
   runtimeCompiler: true,
   devServer: {
     proxy: {
-      '^/auto/search/json$': {
+      '^/api/search$': {
         target: 'http://auto-viewer.spec.edmcouncil.org',
-        changeOrigin: true,
-        secure:false,
-        pathRewrite: {'^/auto': '/'},
+        // changeOrigin: true,
+        // secure:false,
+        // pathRewrite: {'^/auto': '/'},
         //logLevel: 'debug'
       },
-      '^/auto/module/json$': {
+      '^/api/module$': {
         target: 'http://auto-viewer.spec.edmcouncil.org',
-        changeOrigin: true,
-        secure:false,
-        pathRewrite: {'^/auto': '/'},
+        // changeOrigin: true,
+        // secure:false,
+        // pathRewrite: {'^/auto': '/'},
         //logLevel: 'debug'
       },
-      '^/auto/hint': {
+      '^/api/hint': {
         target: 'http://auto-viewer.spec.edmcouncil.org',
-        changeOrigin: true,
-        secure:false,
-        pathRewrite: {'^/auto': '/'},
+        // changeOrigin: true,
+        // secure:false,
+        // pathRewrite: {'^/auto': '/'},
         //logLevel: 'debug'
       },
     },

--- a/fibo/src/store/index.js
+++ b/fibo/src/store/index.js
@@ -7,8 +7,8 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    ontologyDefaultDomain: '/api/search',
-    modulesDefaultDomain: '/api/module',
+    ontologyDefaultDomain: '/fibo/ontology/api/search',
+    modulesDefaultDomain: '/fibo/ontology/api/module',
   },
   mutations: {
 

--- a/fibo/src/store/index.js
+++ b/fibo/src/store/index.js
@@ -7,8 +7,8 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    ontologyDefaultDomain: '/search/json',
-    modulesDefaultDomain: '/module/json',
+    ontologyDefaultDomain: '/api/search',
+    modulesDefaultDomain: '/api/module',
   },
   mutations: {
 

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -515,7 +515,7 @@ export default {
 
       this.searchBox.isLoading = true;
       try {
-        const result = await getHint(query, '/api/hint');
+        const result = await getHint(query, '/fibo/ontology/api/hint');
         const hints = await result.json();
         hints.forEach((el) => {
           // eslint-disable-next-line no-param-reassign

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -515,7 +515,7 @@ export default {
 
       this.searchBox.isLoading = true;
       try {
-        const result = await getHint(query, '/hint');
+        const result = await getHint(query, '/api/hint');
         const hints = await result.json();
         hints.forEach((el) => {
           // eslint-disable-next-line no-param-reassign

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -131,7 +131,7 @@
                     {{data.iri}}
                     <button v-clipboard="data.iri" type="button" class="btn btn-sm btn-outline-primary">Copy</button>
                   </h6>
-                  <h6 class="card-subtitle mb-2 text-muted" v-if="data.qName">
+                  <h6 class="card-subtitle mb-2 text-muted" v-if="data.qName && data.qName !== ''">
                     {{data.qName}}
                     <button v-clipboard="data.qName.replace('QName: ', '')" type="button" class="btn btn-sm btn-outline-primary">Copy</button>
                   </h6>

--- a/fibo/vue.config.js
+++ b/fibo/vue.config.js
@@ -17,13 +17,13 @@ module.exports = {
   runtimeCompiler: true,
   devServer: {
     proxy: {
-      '^/search/json': {
+      '^/api/search': {
         target: 'https://spec.edmcouncil.org',
       },
-      '^/module/json$': {
+      '^/api/module$': {
         target: 'https://spec.edmcouncil.org',
       },
-      '^/hint': {
+      '^/api/hint': {
         target: 'https://spec.edmcouncil.org',
       },
     },

--- a/fibo/vue.config.js
+++ b/fibo/vue.config.js
@@ -17,13 +17,13 @@ module.exports = {
   runtimeCompiler: true,
   devServer: {
     proxy: {
-      '^/api/search': {
+      '^/fibo/ontology/api/search': {
         target: 'https://spec.edmcouncil.org',
       },
-      '^/api/module$': {
+      '^/fibo/ontology/api/module$': {
         target: 'https://spec.edmcouncil.org',
       },
-      '^/api/hint': {
+      '^/fibo/ontology/api/hint': {
         target: 'https://spec.edmcouncil.org',
       },
     },


### PR DESCRIPTION
Updating the auto ontology page to the latest version of the viewer
analogous changes as in Commit: 479f03f87d265811a6f54a0255b01db9051de089 [479f03f]
FIBO-128
Change json processing on the website for the new version of ontology-viewer
- The new json has some changes in its type response: details. Taxonomy now has a list of iri and labels, previously it consisted of value and type. The same like taxonomy works now 'Instances'. Graph now is an object not text to parse.

Signed-off-by: Kamil Balcerzak <kbalcerek@o2.pl>