### PR TITLE
FIBO-175 New list styling AUTO and FIBO website (WIP)

### DIFF
--- a/auto/src/views/Ontology.vue
+++ b/auto/src/views/Ontology.vue
@@ -154,9 +154,24 @@
                         v-for="( property, name ) in data.properties[sectionName]"
                         :key="name"
                       >
-                        <dt class="col-sm-3">{{name}}</dt>
-                        <dd class="col-sm-9">
+                        <dt class="col-sm-12">{{name}}</dt>
+                        <dd class="col-sm-12">
+                          <ul v-if="property.length > 1">
+                            <li
+                              v-for="field in property"
+                              :key="field.id"
+                            >
+                              <component
+                                :is="field.type"
+                                :value="field.value"
+                                :entityMaping="field.entityMaping"
+                                v-bind="field"
+                              ></component>
+                            </li>
+                          </ul>
+                          
                           <component
+                            v-else
                             v-for="field in property"
                             :key="field.id"
                             :is="field.type"
@@ -628,5 +643,17 @@ article ul.maturity-levels li:before{
 .multiselect__option--highlight:after {
   background: #f3f3f3;
   color: #000;
+}
+dd{
+  margin-left: 20px;
+
+  ul{
+    padding-left: 0px;
+  }
+
+  > div{
+    margin-top: 5px;
+    margin-left: 7px;
+  }
 }
 </style>

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -176,9 +176,24 @@
                         v-for="( property, name ) in data.properties[sectionName]"
                         :key="name"
                       >
-                        <dt class="col-sm-3">{{name}}</dt>
-                        <dd class="col-sm-9">
+                        <dt class="col-sm-12">{{name}}</dt>
+                        <dd class="col-sm-12">
+                          <ul v-if="property.length > 1">
+                            <li
+                              v-for="field in property"
+                              :key="field.id"
+                            >
+                              <component
+                                :is="field.type"
+                                :value="field.value"
+                                :entityMaping="field.entityMaping"
+                                v-bind="field"
+                              ></component>
+                            </li>
+                          </ul>
+                          
                           <component
+                            v-else
                             v-for="field in property"
                             :key="field.id"
                             :is="field.type"
@@ -691,6 +706,18 @@ article ul.maturity-levels li:before{
     .page-link{
       background-color: #2a83be;
     }
+  }
+}
+dd{
+  margin-left: 20px;
+
+  ul{
+    padding-left: 0px;
+  }
+
+  > div{
+    margin-top: 5px;
+    margin-left: 7px;
   }
 }
 </style>


### PR DESCRIPTION
New list styling AUTO and FIBO website
The new styling could look like the example below. When element is an single - without 'dot', when more than one - any element should have a 'dot'.
The changes should be on the auto and fibo pages.
The changes should affect the displayed ontology resources, ex https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/LegalEntity or https://spec.edmcouncil.org/auto/ontology/EC/AutoSchemaOrg/Car

Signed-off-by: Kamil Balcerzak <kbalcerek@o2.pl>