### PR TITLE
FIBO-138

### DIFF
--- a/fibo/src/api/ontology.js
+++ b/fibo/src/api/ontology.js
@@ -20,12 +20,19 @@ const getModules = function (domain) {
 };
 
 const getHint = function (query, domain) {
-  return fetch(domain + '/', {
+  return fetch(domain, {
     method: 'POST',
     headers: { 'Accept': 'application/json', 'Content-Type': 'text/plain' },
     body: query,
   }).then(parseServerError);
 };
 
+const getOntologyVersions = function () {
+  return fetch('/fibo/ontology/api/', {
+    method: 'GET',
+    headers: { 'Accept': 'application/json' },
+  }).then(parseServerError);
+};
 
-export { getOntology, getModules, getHint };
+
+export { getOntology, getModules, getHint, getOntologyVersions };

--- a/fibo/src/components/ModuleTree.vue
+++ b/fibo/src/components/ModuleTree.vue
@@ -46,9 +46,18 @@ export default {
       this.isOpen = !this.isOpen;
     },
     ontologyClicked(event) {
+    },
+    expandOpened(loc) {
+      if (loc && loc.locationInModules) {
+        this.isSelected = loc.locationInModules.some(
+          location => location == this.item.iri,
+        );
+        this.isOpen = /* this.isOpen || */ this.isSelected; //isOpen is commented out to enable collapsing tree after opening different branch 
+      }
     }
   },
   mounted() {
+    this.expandOpened(this.location);
   },
   computed: {
     isFolder() {
@@ -58,12 +67,7 @@ export default {
   watch: {
     location: {
       handler(val, oldVal) {
-        if (val && val.locationInModules) {
-          this.isSelected = val.locationInModules.some(
-            location => location == this.item.iri,
-          );
-          this.isOpen = /* this.isOpen || */ this.isSelected; //isOpen is commented out to enable collapsing tree after opening different branch 
-        }
+        this.expandOpened(val);
       },
       deep: true,
     },

--- a/fibo/src/components/VisNetwork.vue
+++ b/fibo/src/components/VisNetwork.vue
@@ -113,6 +113,9 @@ export default {
       network.redraw();
 
       network.on('doubleClick', (params) => {
+        var versionQueryStringPart = (this.$route.query && this.$route.query.version
+          ? 'version=' + encodeURI(this.$route.query.version)
+          : null);
         params.event = '[original event]';
         const selectedNodes = params.nodes;
         const selectedEdges = params.edges;
@@ -122,9 +125,9 @@ export default {
           nodes.forEach((entry) => {
             if (entry.id === sNode) {
               if(entry.iri.match(/^https:\/\/spec\.edmcouncil\.org\/fibo/)){
-                window.location.href = `/fibo${entry.iri.replace('https://spec.edmcouncil.org/fibo', '')}`; //&scrollToTop=true
+                window.location.href = `/fibo${entry.iri.replace('https://spec.edmcouncil.org/fibo', '')}?${versionQueryStringPart}`; //&scrollToTop=true
               }else{
-                window.location.href = `/fibo/ontology?query=${entry.iri}`; //&scrollToTop=true
+                window.location.href = `/fibo/ontology?query=${entry.iri}&${versionQueryStringPart}`; //&scrollToTop=true
               }
             }
           });
@@ -133,9 +136,9 @@ export default {
           edgesView.forEach((entry) => {
             if (entry.id === sEgde) {
               if(entry.iri.match(/^https:\/\/spec\.edmcouncil\.org\/fibo/)){
-                window.location.href = `/fibo${entry.iri.replace('https://spec.edmcouncil.org/fibo', '')}`; //&scrollToTop=true
+                window.location.href = `/fibo${entry.iri.replace('https://spec.edmcouncil.org/fibo', '')}?${versionQueryStringPart}`; //&scrollToTop=true
               }else{
-                window.location.href = `/fibo/ontology?query=${entry.iri}`; //&scrollToTop=true
+                window.location.href = `/fibo/ontology?query=${entry.iri}&${versionQueryStringPart}`; //&scrollToTop=true
               }
             }
           });

--- a/fibo/src/components/chunks/link.vue
+++ b/fibo/src/components/chunks/link.vue
@@ -1,8 +1,27 @@
 <template>
   <router-link v-if="query.match(/^https:\/\/spec\.edmcouncil\.org\/fibo/)"
-    :to="{ path: query.replace(/https:\/\/spec\.edmcouncil\.org\/fibo/,'') }"
-    @click.native="linkClickNative">{{name}}</router-link>
-  <router-link v-else :to="{ name: 'ontology', query: { query }}">{{name}}</router-link>
+    :to="{
+      path: query.replace(/https:\/\/spec\.edmcouncil\.org\/fibo/,''),
+      query: {
+        ...(this.$route.query && this.$route.query.version
+          ? { version: encodeURI(this.$route.query.version) }
+          : null)
+      }
+    }"
+    @click.native="linkClickNative"
+    >{{name}}</router-link>
+  <router-link v-else
+    :to="{
+      name: 'ontology',
+      query: {
+        ...{query},
+        ...(this.$route.query && this.$route.query.version
+          ? { version: encodeURI(this.$route.query.version) }
+          : null)
+      }
+    }"
+    >{{name}}</router-link>
+  
 </template>
 <script>
 export default {

--- a/fibo/src/store/index.js
+++ b/fibo/src/store/index.js
@@ -7,8 +7,8 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    ontologyDefaultDomain: '/fibo/ontology/api/search',
-    modulesDefaultDomain: '/fibo/ontology/api/module',
+    ontologyDefaultDomain: '/fibo/ontology/{version}api/search',
+    modulesDefaultDomain: '/fibo/ontology/{version}api/module',
   },
   mutations: {
 

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -462,6 +462,10 @@ export default {
       hintServer: null,
       hintDefaultDomain: '/fibo/ontology/{version}api/hint/',
       version: null,
+      versionDefaultSelectedData: {
+        '@id': 'default',
+        'url': ''
+      },
       modulesList: null,
       error: false,
       searchBox: {
@@ -560,6 +564,7 @@ export default {
         const result = await getOntologyVersions();
         const ontologyVersions = await result.json();
         this.ontologyVersionsDropdownData.data = ontologyVersions;
+        ontologyVersions.unshift(this.versionDefaultSelectedData); // add default at the beginning
 
         if (this.version !== null) {
           this.ontologyVersionsDropdownData.selectedData = ontologyVersions.find((val, ind) => {
@@ -569,7 +574,7 @@ export default {
             return false;
           });
         } else {
-          this.ontologyVersionsDropdownData.selectedData = null;
+          this.ontologyVersionsDropdownData.selectedData = this.versionDefaultSelectedData;
         }
         this.error = false;
       } catch (err) {
@@ -589,7 +594,12 @@ export default {
 
     // vue-multiselect ontologyVersions
     ontologyVersions_optionSelected(selectedOntologyVersion /* , id */) {
-      this.$router.push({ query: { version: encodeURI(selectedOntologyVersion['@id']) } });
+      if(selectedOntologyVersion['@id'] === this.versionDefaultSelectedData['@id']){
+        //default selected
+        this.$router.push({ query: { } });
+      }else{
+        this.$router.push({ query: { version: encodeURI(selectedOntologyVersion['@id']) } });
+      }
 
       //clear search results after changing version
       this.searchBox = {

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -505,9 +505,7 @@ export default {
     this.updateServers();
 
     this.query = queryParam;
-    this.$nextTick(async function () {
-      this.fetchData(this.query);
-    });
+    this.fetchData(this.query);
     this.fetchModules();
   },
   methods: {

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -153,7 +153,7 @@
 
               <div class="alert alert-primary alert-maturity" role="alert" v-if="data.maturityLevel.label != 'release' && data.maturityLevel.label != ''">
                 This resource has maturity level <strong>{{this.data.maturityLevel.label}}</strong>. Read more about
-                <customLink class="custom-link" :name="this.data.maturityLevel.label" :query="data.maturityLevel.iri" :customLinkOnClick="this.ontologyClicked"></customLink>.
+                <customLink class="custom-link" :name="this.data.maturityLevel.label" :query="data.maturityLevel.iri"></customLink>.
               </div>
 
               <div class="card">

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -596,9 +596,17 @@ export default {
     ontologyVersions_optionSelected(selectedOntologyVersion /* , id */) {
       if(selectedOntologyVersion['@id'] === this.versionDefaultSelectedData['@id']){
         //default selected
-        this.$router.push({ query: { } });
+        const {version, ...rest} = this.$route.query; //get rid of version
+        this.$router.push({ query: rest });
       }else{
-        this.$router.push({ query: { version: encodeURI(selectedOntologyVersion['@id']) } });
+        this.$router.push({
+          query: {
+            ...this.$route.query,
+            ...{
+              version: encodeURI(selectedOntologyVersion['@id'])
+            }
+          }
+        });
       }
 
       //clear search results after changing version

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -611,15 +611,38 @@ export default {
       if (destRoute.startsWith('https://spec.edmcouncil.org/fibo')) {
         // internal ontology
         destRoute = destRoute.replace('https://spec.edmcouncil.org/fibo', '');
-        this.$router.push(destRoute);
+        this.$router.push({
+          path: destRoute,
+          query: {
+            ...(this.$route.query && this.$route.query.version
+              ? { version: encodeURI(this.$route.query.version) }
+              : null)
+          }
+        });
       } else {
         // external ontology
-        this.$router.push({ path: '/ontology', query: { query: encodeURI(destRoute) } });
+        this.$router.push({
+          path: '/ontology',
+          query: {
+            ...{ query: encodeURI(destRoute) },
+            ...(this.$route.query && this.$route.query.version
+              ? { version: encodeURI(this.$route.query.version) }
+              : null)
+          }
+        });
       }
       this.scrollToOntologyViewerTopOfContainer();
     },
     async searchBox_addTag(newTag) {
-      this.$router.push({ path: '/ontology', query: { searchBoxQuery: encodeURI(newTag) } });
+      this.$router.push({
+        path: '/ontology',
+        query: {
+          ...{ searchBoxQuery: encodeURI(newTag) },
+          ...(this.$route.query && this.$route.query.version
+            ? { version: encodeURI(this.$route.query.version) }
+            : null)
+        }
+      });
     },
     async handleSearchBoxQuery(searchBQuery, pageIndex = null) {
       try {

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -852,6 +852,7 @@ article ul.maturity-levels li:before{
 }
 .multiselect-xxl-container{
   margin-top: 20px;
+  min-width: 250px;
 }
 </style>
 

--- a/fibo/vue.config.js
+++ b/fibo/vue.config.js
@@ -17,13 +17,16 @@ module.exports = {
   runtimeCompiler: true,
   devServer: {
     proxy: {
-      '^/fibo/ontology/api/search': {
+      '^/fibo/ontology/.*api/search': {
         target: 'https://spec.edmcouncil.org',
       },
-      '^/fibo/ontology/api/module$': {
+      '^/fibo/ontology/.*api/module$': {
         target: 'https://spec.edmcouncil.org',
       },
-      '^/fibo/ontology/api/hint': {
+      '^/fibo/ontology/.*api/hint': {
+        target: 'https://spec.edmcouncil.org',
+      },
+      '^/fibo/ontology/api': {
         target: 'https://spec.edmcouncil.org',
       },
     },


### PR DESCRIPTION
Implement displaying FIBO versions (frontend)
1. Create drop-down list (above tree on Fibo Viewer page ???) of ontology versions (GET /fibo/ontology/api/) and depending on the selected version, use url value from returned json for rest api endpoint
2. Add query value ?version=BRANCH/TAG to choose ontology version using URL (eg. Business Entities for version=master/2020Q1)
3. Enable authorized (required X-API-Key) users do add/delete instances = add/delete items in drop-down list

Signed-off-by: Kamil Balcerzak <kbalcerek@o2.pl>