### PR TITLE
FIBO-138

### DIFF
--- a/fibo/src/styles/global.scss
+++ b/fibo/src/styles/global.scss
@@ -133,3 +133,7 @@ article ul.space-at-top li::before {
     top: 12px;
     right: 4px;
   }
+
+  .btn-outline-primary{
+      margin-right:  10px;
+  }

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -162,6 +162,10 @@
                   <h6 class="card-subtitle mb-2 text-muted" v-if="data.iri">
                     {{data.iri}}
                     <button v-clipboard="data.iri" type="button" class="btn btn-sm btn-outline-primary">Copy</button>
+                    <button 
+                      v-if="this.$route.query && this.$route.query.version"
+                      v-clipboard="data.iri + '?version=' + encodeURI(this.$route.query.version)" 
+                      type="button" class="btn btn-sm btn-outline-primary">Copy versioned IRI</button>
                   </h6>
                   <h6 class="card-subtitle mb-2 text-muted" v-if="data.qName && data.qName !== ''">
                     {{data.qName}}
@@ -463,7 +467,7 @@ export default {
       hintDefaultDomain: '/fibo/ontology/{version}api/hint/',
       version: null,
       versionDefaultSelectedData: {
-        '@id': 'default',
+        '@id': '<DEFAULT>',
         'url': ''
       },
       modulesList: null,


### PR DESCRIPTION
Implement displaying FIBO versions (frontend)
- the "default" version should look different than other versions, e.g "DEFAULT" or "<DEFAULT>"
- when a version other than the "default" is displayed, then to the right of the "Copy" button next to the IRI there should be a button similar to "Copy" - e.g "Copy versioned IRI" with an IRI containing "...? version = <VERSION>"

Signed-off-by: Kamil Balcerzak <kbalcerek@o2.pl>