### PR TITLE
Displays flag icons instead of language tags

### DIFF
--- a/auto/package-lock.json
+++ b/auto/package-lock.json
@@ -5467,6 +5467,11 @@
         "locate-path": "^2.0.0"
       }
     },
+    "flag-icon-css": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-3.5.0.tgz",
+      "integrity": "sha512-pgJnJLrtb0tcDgU1fzGaQXmR8h++nXvILJ+r5SmOXaaL/2pocunQo2a8TAXhjQnBpRLPtZ1KCz/TYpqeNuE2ew=="
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -11807,6 +11812,14 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
+    "vue-lang-code-flags": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vue-lang-code-flags/-/vue-lang-code-flags-1.0.13.tgz",
+      "integrity": "sha512-s0MuSMFuf8oN83TNXxSjidrQp9aVKJS1GE2bf/6mNPTHyER8pAD49R9JSH/Xry793z93/G1vGZDAw9fdnfUfLQ==",
+      "requires": {
+        "flag-icon-css": "^3.2.0"
+      }
+    },
     "vue-loader": {
       "version": "15.7.0",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.0.tgz",
@@ -12446,6 +12459,11 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yarn": {
+      "version": "1.22.17",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.17.tgz",
+      "integrity": "sha512-H0p241BXaH0UN9IeH//RT82tl5PfNraVpSpEoW+ET7lmopNC61eZ+A+IDvU8FM6Go5vx162SncDL8J1ZjRBriQ=="
     },
     "yorkie": {
       "version": "2.0.0",

--- a/auto/package.json
+++ b/auto/package.json
@@ -19,9 +19,11 @@
     "vis-network": "^6.4.0",
     "vue": "^2.6.10",
     "vue-gtag": "^1.10.0",
+    "vue-lang-code-flags": "^1.0.13",
     "vue-multiselect": "^2.1.6",
     "vue-router": "^3.0.3",
-    "vuex": "^3.0.1"
+    "vuex": "^3.0.1",
+    "yarn": "^1.22.17"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.8.0",

--- a/auto/src/components/chunks/AXIOM.vue
+++ b/auto/src/components/chunks/AXIOM.vue
@@ -33,9 +33,36 @@ export default {
         customLink
     },
     props: ["value", "entityMaping"],
+       data() {
+        const regexLang = /\[[a-z]{2}\]|@[a-z]{2}/
+        let html = this.value;
+        let lines = html.split(/(?:\r\n|\r|\n)/g);
+        if (lines.length == 1) {
+            lines = html.split("<br />");
+        }
+        lines.forEach(function(part, index){
+            console.log(part);
+            
+          var regexMatch = part.match(regexLang);
+          console.log(regexMatch);
+          if(regexMatch!=null) {
+            regexMatch.forEach(function(match, indexMatch){
+              var replacementLang = match.replace("[","").replace("]","").replace("@", "");
+              var rep = part.replace(match, `<lang-flag iso="${replacementLang}" />`);
+              lines[index] = rep;
+              }, regexMatch);
+            
+          }
+        }, lines);
+        return {
+            lines: lines,
+            isShowMore: false,
+            isMoreVisible: false
+        };
+    },
     computed: {
         fullProcessedHtml() {
-            let html = this.processedHtml(this.value);
+            let html = this.processedHtml(this.lines.join("<br />"));
             return {
                 template: `<div>${html}</div>`
             };
@@ -53,18 +80,7 @@ export default {
             };
         }
     },
-    data() {
-        let html = this.value;
-        let lines = html.split(/(?:\r\n|\r|\n)/g);
-        if (lines.length == 1) {
-            lines = html.split("<br />");
-        }
-        return {
-            lines: lines,
-            isShowMore: false,
-            isMoreVisible: false
-        };
-    },
+ 
 
     mounted() {
         if (this.lines.length > 6) {

--- a/auto/src/components/chunks/STRING.vue
+++ b/auto/src/components/chunks/STRING.vue
@@ -1,22 +1,19 @@
 <template>
-<div>
-    <div 
-      v-if="!isShowMore" 
-      v-html="lines.join('<br />')" />
+<div v-if="!isShowMore">
+    <component v-bind:is="fullProcessedHtml"></component>
+</div>
+<div v-else>
+    <component v-bind:is="sliceProcessedHtml">
+    </component>
+    <a href="#" 
+      v-show="!isMoreVisible" 
+      @click.prevent="isMoreVisible = !isMoreVisible">
+        See more...
+    </a>
 
-    <div v-else>
-        <div v-html="lines.slice(0, 5).join('<br />')" />
+    <div v-show="isMoreVisible">
+        <component v-bind:is="moreProcessedHtml"></component>
         <a href="#" 
-          v-show="!isMoreVisible" 
-          @click.prevent="isMoreVisible = !isMoreVisible">
-            See more...
-        </a>
-
-        <div v-show="isMoreVisible" 
-          v-html="lines.slice(5).join('<br />')" />
-
-        <a href="#" 
-          v-show="isMoreVisible" 
           @click.prevent="isMoreVisible = !isMoreVisible">
             See less...
         </a>
@@ -28,17 +25,51 @@
 export default {
     name: 'STRING',
     props: ['value'],
-
+    computed: {
+        fullProcessedHtml() {
+            let html = this.lines.join("<br />");
+            return {
+                template: `<div>${html}</div>`
+            };
+        },
+        sliceProcessedHtml() {
+            let html = this.lines.slice(0, 6).join("<br />");
+            return {
+                template: `<div>${html}</div>`
+            };
+        },
+        moreProcessedHtml() {
+            let html = this.lines.slice(6).join("<br />");
+            return {
+                template: `<div>${html}</div>`
+            };
+        }
+    },
     data() {
-        return {
-            lines: this.value.split(/(?:\r\n|\r|\n)/g),
-            isShowMore: false,
-            isMoreVisible: false,
-        };
+      const regexLang = /\[[a-z]{2}\]|@[a-z]{2}/
+      var tlines = this.value.split(/(?:\r\n|\r|\n)/g);
+        tlines.forEach(function(part, index){
+            console.log(part);
+            console.log(part.match(regexLang));
+          var regexMatch = part.match(regexLang);
+          if(regexMatch!=null) {
+            regexMatch.forEach(function(match, indexMatch){
+              var replacementLang = match.replace("[","").replace("]","");
+              var rep = part.replace(match, `<lang-flag iso="${replacementLang}" />`);
+              tlines[index] = rep;
+              }, regexMatch);
+            
+          }
+        }, tlines);
+      return {
+          lines: tlines,
+          isShowMore: false,
+          isMoreVisible: false,
+      };
     },
 
     mounted() {
-        if (this.lines.length > 5) { // yes 6, first line is "title"
+        if (this.lines.length > 6) { // yes 6, first line is "title"
             this.isShowMore = true;
         }
     },

--- a/auto/src/main.js
+++ b/auto/src/main.js
@@ -7,9 +7,13 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import ModuleTree from './components/ModuleTree.vue';
+import LangFlag from 'vue-lang-code-flags';
+
+LangFlag.props.squared = {type: Boolean, default: false};
 
 Vue.config.productionTip = false;
 Vue.component('module-tree', ModuleTree);
+Vue.component('lang-flag', LangFlag);
 Vue.use(Clipboard);
 
 Vue.config.productionTip = false;

--- a/fibo/package-lock.json
+++ b/fibo/package-lock.json
@@ -5467,6 +5467,11 @@
         "locate-path": "^2.0.0"
       }
     },
+    "flag-icon-css": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-3.5.0.tgz",
+      "integrity": "sha512-pgJnJLrtb0tcDgU1fzGaQXmR8h++nXvILJ+r5SmOXaaL/2pocunQo2a8TAXhjQnBpRLPtZ1KCz/TYpqeNuE2ew=="
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -11811,6 +11816,14 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
+    },
+    "vue-lang-code-flags": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vue-lang-code-flags/-/vue-lang-code-flags-1.0.13.tgz",
+      "integrity": "sha512-s0MuSMFuf8oN83TNXxSjidrQp9aVKJS1GE2bf/6mNPTHyER8pAD49R9JSH/Xry793z93/G1vGZDAw9fdnfUfLQ==",
+      "requires": {
+        "flag-icon-css": "^3.2.0"
+      }
     },
     "vue-loader": {
       "version": "15.7.0",

--- a/fibo/package.json
+++ b/fibo/package.json
@@ -20,6 +20,7 @@
     "vue": "^2.6.10",
     "vue-analytics": "^5.17.2",
     "vue-gtag": "^1.16.1",
+    "vue-lang-code-flags": "^1.0.13",
     "vue-multiselect": "^2.1.6",
     "vue-router": "^3.0.3",
     "vuejs-paginate": "^2.1.0",

--- a/fibo/src/components/chunks/AXIOM.vue
+++ b/fibo/src/components/chunks/AXIOM.vue
@@ -33,9 +33,36 @@ export default {
         customLink
     },
     props: ["value", "entityMaping"],
+       data() {
+        const regexLang = /\[[a-z]{2}\]|@[a-z]{2}/
+        let html = this.value;
+        let lines = html.split(/(?:\r\n|\r|\n)/g);
+        if (lines.length == 1) {
+            lines = html.split("<br />");
+        }
+        lines.forEach(function(part, index){
+            console.log(part);
+            
+          var regexMatch = part.match(regexLang);
+          console.log(regexMatch);
+          if(regexMatch!=null) {
+            regexMatch.forEach(function(match, indexMatch){
+              var replacementLang = match.replace("[","").replace("]","").replace("@", "");
+              var rep = part.replace(match, `<lang-flag iso="${replacementLang}" />`);
+              lines[index] = rep;
+              }, regexMatch);
+            
+          }
+        }, lines);
+        return {
+            lines: lines,
+            isShowMore: false,
+            isMoreVisible: false
+        };
+    },
     computed: {
         fullProcessedHtml() {
-            let html = this.processedHtml(this.value);
+            let html = this.processedHtml(this.lines.join("<br />"));
             return {
                 template: `<div>${html}</div>`
             };
@@ -53,18 +80,7 @@ export default {
             };
         }
     },
-    data() {
-        let html = this.value;
-        let lines = html.split(/(?:\r\n|\r|\n)/g);
-        if (lines.length == 1) {
-            lines = html.split("<br />");
-        }
-        return {
-            lines: lines,
-            isShowMore: false,
-            isMoreVisible: false
-        };
-    },
+ 
 
     mounted() {
         if (this.lines.length > 6) {

--- a/fibo/src/components/chunks/STRING.vue
+++ b/fibo/src/components/chunks/STRING.vue
@@ -1,22 +1,19 @@
 <template>
-<div>
-    <div 
-      v-if="!isShowMore" 
-      v-html="lines.join('<br />')" />
+<div v-if="!isShowMore">
+    <component v-bind:is="fullProcessedHtml"></component>
+</div>
+<div v-else>
+    <component v-bind:is="sliceProcessedHtml">
+    </component>
+    <a href="#" 
+      v-show="!isMoreVisible" 
+      @click.prevent="isMoreVisible = !isMoreVisible">
+        See more...
+    </a>
 
-    <div v-else>
-        <div v-html="lines.slice(0, 6).join('<br />')" />
+    <div v-show="isMoreVisible">
+        <component v-bind:is="moreProcessedHtml"></component>
         <a href="#" 
-          v-show="!isMoreVisible" 
-          @click.prevent="isMoreVisible = !isMoreVisible">
-            See more...
-        </a>
-
-        <div v-show="isMoreVisible" 
-          v-html="lines.slice(6).join('<br />')" />
-
-        <a href="#" 
-          v-show="isMoreVisible" 
           @click.prevent="isMoreVisible = !isMoreVisible">
             See less...
         </a>
@@ -28,13 +25,47 @@
 export default {
     name: 'STRING',
     props: ['value'],
-
+    computed: {
+        fullProcessedHtml() {
+            let html = this.lines.join("<br />");
+            return {
+                template: `<div>${html}</div>`
+            };
+        },
+        sliceProcessedHtml() {
+            let html = this.lines.slice(0, 6).join("<br />");
+            return {
+                template: `<div>${html}</div>`
+            };
+        },
+        moreProcessedHtml() {
+            let html = this.lines.slice(6).join("<br />");
+            return {
+                template: `<div>${html}</div>`
+            };
+        }
+    },
     data() {
-        return {
-            lines: this.value.split(/(?:\r\n|\r|\n)/g),
-            isShowMore: false,
-            isMoreVisible: false,
-        };
+      const regexLang = /\[[a-z]{2}\]|@[a-z]{2}/
+      var tlines = this.value.split(/(?:\r\n|\r|\n)/g);
+        tlines.forEach(function(part, index){
+            console.log(part);
+            console.log(part.match(regexLang));
+          var regexMatch = part.match(regexLang);
+          if(regexMatch!=null) {
+            regexMatch.forEach(function(match, indexMatch){
+              var replacementLang = match.replace("[","").replace("]","");
+              var rep = part.replace(match, `<lang-flag iso="${replacementLang}" />`);
+              tlines[index] = rep;
+              }, regexMatch);
+            
+          }
+        }, tlines);
+      return {
+          lines: tlines,
+          isShowMore: false,
+          isMoreVisible: false,
+      };
     },
 
     mounted() {

--- a/fibo/src/main.js
+++ b/fibo/src/main.js
@@ -8,9 +8,13 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import ModuleTree from './components/ModuleTree.vue';
+import LangFlag from 'vue-lang-code-flags';
+
+LangFlag.props.squared = {type: Boolean, default: false};
 
 Vue.config.productionTip = false;
 Vue.component('module-tree', ModuleTree);
+Vue.component('lang-flag', LangFlag);
 Vue.use(Clipboard);
 
 Vue.config.productionTip = false;


### PR DESCRIPTION
To display language flags, I used the vue-lang-code-flags package under the MIT license. Changes were implemented for fibo and auto pages. 

If pr should be to another branch please let me know and I will correct it

Issue: #104 

Signed-off-by: dasawanaka <michal.19.daniel.96@gmail.com>