### PR TITLE
Advanced search in mobile display

### DIFF
--- a/fibo/src/styles/views/Ontology.scss
+++ b/fibo/src/styles/views/Ontology.scss
@@ -261,7 +261,7 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
 }
 .multiselect-container.secondary-column__versions.secondary-column__versions--mobile{
   background-color: transparent;
-  margin-top: 0px;
+  margin-top: 30px;
   .menu-box {
     margin-top: 0px;
     box-shadow: 0px 5px 20px -5px rgba(8, 84, 150, 0.15);
@@ -450,6 +450,7 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
 }
 .search-box--mobile {
   background-color: transparent;
+  padding: 0 20px 0px 20px;
   .menu-box {
     margin-bottom: 10px;
     box-shadow: 0px 5px 20px -5px rgba(8, 84, 150, 0.15);
@@ -457,21 +458,6 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
   .multiselect__content-wrapper {
     box-shadow: inset 0px 20px 20px -20px rgba(8, 84, 150, 0.15),
                 0px 5px 20px -5px rgba(8, 84, 150, 0.15);
-  }
-  .multiselect .multiselect__select {
-    display: block;
-    transition: right 0.2s, background-color 0.2s;
-    background-color: white;
-    padding: 0px;
-    margin-right: 30px;
-    margin-top: -10px;
-    width: 40px;
-    height: 40px;
-    top: -5px;
-    background-image: url("../../assets/icons/search.svg");
-    background-repeat: no-repeat;
-    background-size: 24px 24px;
-    background-position: center;
   }
 }
 
@@ -615,6 +601,17 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
         }
       }
     }
+  }
+}
+.advanced-search-box--mobile {
+  background: none;
+  margin-top: 10px;
+  .multiselect__content-wrapper {
+    box-shadow: inset 0px 20px 20px -20px rgba(8, 84, 150, 0.15),
+                0px 5px 20px -5px rgba(8, 84, 150, 0.15);
+  }
+  .custom-checkbox {
+    padding-bottom: 0px;
   }
 }
 
@@ -1435,7 +1432,7 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
 // --------------------------
 // Mobile
 // --------------------------
-@media (max-width: 768px) {
+@media (max-width: 991px) {
   .section-title {
     &::before {
       content: "";
@@ -1634,6 +1631,7 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
   }
 
   .search-section {
+    margin-top: 45px;
     .search-section__header {
       padding: 40px 30px;
 
@@ -1763,6 +1761,12 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
       width: 24px;
       height: 24px;
       float: left;
+    }
+  }
+
+  .custom-checkbox {
+    .custom-control-label {
+      font-size: 16px;
     }
   }
 }

--- a/fibo/src/styles/views/Ontology.scss
+++ b/fibo/src/styles/views/Ontology.scss
@@ -1562,7 +1562,6 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
     }
 
     .ontology-item__header {
-      margin-top: 0px;
       // maturity alert
       .alert-maturity {
         margin-top: 40px;

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -123,13 +123,18 @@
                         id="ajax2"
                         label="labelForInternalSearch"
                         track-by="iri"
-                        :placeholder="searchBox.inputValue || 'Find domains, ontologies, concepts...'"
+                        :placeholder="
+                          searchBox.inputValue ||
+                          'Find domains, ontologies, concepts...'
+                        "
                         tagPlaceholder="Search..."
                         selectLabel="x"
                         open-direction="bottom"
                         ref="searchBoxInput2"
                         spellcheck="false"
-                        :class="{'multiselect--input-empty':!searchBox.inputValue}"
+                        :class="{
+                          'multiselect--input-empty': !searchBox.inputValue,
+                        }"
                         :options="searchBox.data"
                         :multiple="false"
                         :searchable="true"
@@ -163,17 +168,25 @@
                           query.
                         </span>
                         <span slot="singleLabel">
-                          {{ searchBox.inputValue || 'Find domains, ontologies, concepts...' }}
+                          {{
+                            searchBox.inputValue ||
+                            "Find domains, ontologies, concepts..."
+                          }}
                         </span>
                       </multiselect>
                     </div>
-                    <div class="menu-box__icons"
-                         :class="{'menu-box__icons--inactive':!searchBox.dropdownActive && !searchBox.inputValue,
-                                  'menu-box__icons--loading':searchBox.isLoading}">
+                    <div
+                      class="menu-box__icons"
+                      :class="{
+                        'menu-box__icons--inactive':
+                          !searchBox.dropdownActive && !searchBox.inputValue,
+                        'menu-box__icons--loading': searchBox.isLoading,
+                      }"
+                    >
                       <div
                         class="menu-box__icons__icon icon-search"
-                        @click="searchBox_addTag(searchBox.inputValue)">
-                      </div>
+                        @click="searchBox_addTag(searchBox.inputValue)"
+                      ></div>
                     </div>
                   </div>
                   <!-- <pre class="language-json"><code>{{ searchBox.selectedData }}</code></pre>
@@ -253,71 +266,15 @@
             name="ontologyViewerTopOfContainer"
             id="ontologyViewerTopOfContainer"
           ></a>
+        </div>
 
-          <!-- search box mobile -->
-          <div
-            class="
-              search-box search-box--mobile
-              d-lg-none
-              multiselect-container
-            "
-          >
-            <div class="menu-box">
-              <div class="menu-box__label">Search FIBO</div>
-              <div class="menu-box__content-text">
-                <multiselect
-                  v-model="searchBox.selectedData"
-                  id="ajax"
-                  label="labelForInternalSearch"
-                  track-by="iri"
-                  placeholder="Find..."
-                  tagPlaceholder="Search..."
-                  selectLabel="x"
-                  open-direction="bottom"
-                  ref="searchBoxInput"
-                  spellcheck="false"
-                  :options="searchBox.data"
-                  :multiple="false"
-                  :searchable="true"
-                  :loading="searchBox.isLoading"
-                  :internal-search="false"
-                  :clear-on-select="false"
-                  :close-on-select="true"
-                  :options-limit="300"
-                  :limit="3"
-                  :limit-text="searchBox_limitText"
-                  :max-height="600"
-                  :preserve-search="true"
-                  :show-no-results="false"
-                  :hide-selected="true"
-                  :taggable="true"
-                  @select="searchBox_optionSelected"
-                  @tag="searchBox_addTag"
-                  @search-change="searchBox_asyncFind"
-                >
-                  <template slot="clear" slot-scope="props">
-                    <div
-                      class="multiselect__clear"
-                      v-if="searchBox.selectedData"
-                      @mousedown.prevent.stop="clearAll(props.search)"
-                    ></div>
-                  </template>
-                  <span slot="noResult">
-                    Oops! No elements found. Consider changing the search query.
-                  </span>
-                </multiselect>
-              </div>
-              <div class="menu-box__icons"></div>
-            </div>
-          </div>
-
-          <!-- tree mobile -->
+        <!-- mobile multiselects -->
+        <div class="container px-0 mb-2 d-lg-none">
           <div
             class="
               secondary-column__versions secondary-column__versions--mobile
               multiselect-container
               container
-              d-lg-none
             "
           >
             <div class="menu-box">
@@ -378,7 +335,6 @@
               secondary-column__tree secondary-column__tree--mobile
               multiselect-container
               container
-              d-lg-none
             "
           >
             <div class="menu-box" v-on:click="toggleModuleTree()">
@@ -398,19 +354,149 @@
               :key="item.label"
             />
           </ul>
+
+          <div class="search-box search-box--mobile multiselect-container">
+            <div class="menu-box">
+              <div class="menu-box__label">Search FIBO</div>
+              <div class="menu-box__content-text">
+                <multiselect
+                  v-model="searchBox.selectedData"
+                  id="ajax"
+                  label="labelForInternalSearch"
+                  track-by="iri"
+                  :placeholder="searchBox.inputValue || 'Find...'"
+                  tagPlaceholder="Search..."
+                  selectLabel="x"
+                  open-direction="bottom"
+                  ref="searchBoxInput"
+                  spellcheck="false"
+                  :class="{ 'multiselect--input-empty': !searchBox.inputValue }"
+                  :options="searchBox.data"
+                  :multiple="false"
+                  :searchable="true"
+                  :loading="searchBox.isLoading"
+                  :internal-search="false"
+                  :clear-on-select="false"
+                  :close-on-select="true"
+                  :options-limit="300"
+                  :limit="3"
+                  :limit-text="searchBox_limitText"
+                  :max-height="600"
+                  :preserve-search="true"
+                  :show-no-results="false"
+                  :hide-selected="true"
+                  :taggable="true"
+                  @select="searchBox_optionSelected"
+                  @tag="searchBox_addTag"
+                  @search-change="searchBox_asyncFind"
+                  @open="searchBox.dropdownActive = true"
+                  @close="searchBox.dropdownActive = false"
+                >
+                  <template slot="clear" slot-scope="props">
+                    <div
+                      class="multiselect__clear"
+                      v-if="searchBox.selectedData"
+                      @mousedown.prevent.stop="clearAll(props.search)"
+                    ></div>
+                  </template>
+                  <span slot="noResult">
+                    Oops! No elements found. Consider changing the search query.
+                  </span>
+                  <span slot="singleLabel">
+                    {{ searchBox.inputValue || "Find..." }}
+                  </span>
+                </multiselect>
+              </div>
+              <div
+                class="menu-box__icons"
+                :class="{
+                  'menu-box__icons--inactive':
+                    !searchBox.dropdownActive && !searchBox.inputValue,
+                  'menu-box__icons--loading': searchBox.isLoading,
+                }"
+              >
+                <div
+                  class="menu-box__icons__icon icon-search"
+                  @click="searchBox_addTag(searchBox.inputValue)"
+                ></div>
+              </div>
+            </div>
+            <div
+              class="expand-advanced-btn"
+              @click="
+                searchBox.isAdvancedExpanded = !searchBox.isAdvancedExpanded
+              "
+            >
+              <div v-if="!searchBox.isAdvancedExpanded">
+                <div class="see-more-btn">search configuration</div>
+              </div>
+
+              <div v-else>
+                <div class="see-less-btn">search configuration</div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="advanced-search-box advanced-search-box--mobile card"
+            v-if="searchBox.isAdvancedExpanded"
+          >
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="multiselect-xxl-container multiselect-container">
+                  <div class="menu-box">
+                    <div class="menu-box__label">Search by properties</div>
+                    <div class="menu-box__content-text">
+                      <multiselect
+                        v-model="searchBox.findProperties"
+                        placeholder="Select properties..."
+                        open-direction="bottom"
+                        label="label"
+                        selectLabel=""
+                        deselectLabel=""
+                        selectedLabel=""
+                        track-by="identifier"
+                        :searchable="false"
+                        :options="searchBox.findPropertiesAll"
+                        :close-on-select="false"
+                        :multiple="true"
+                        @input="encodeProperties"
+                      >
+                      </multiselect>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="d-flex justify-content-between align-items-center">
+                  <div class="custom-control custom-checkbox">
+                    <input
+                      v-model="searchBox.useHighlighting"
+                      class="custom-control-input"
+                      type="checkbox"
+                      name="useHighlight"
+                      id="useHighlight"
+                      value="useHighlight"
+                    />
+                    <label class="custom-control-label" for="useHighlight">
+                      Use highlighting
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div
-            class="text-center mt-5"
-            v-if="
-              !error && (loader || searchBox.isLoadingResults || !modulesList)
-            "
-          >
-            <div class="spinner-border" role="status">
-              <span class="sr-only">Loading...</span>
-            </div>
-            <div style="margin-bottom: 100vh"></div>
+          class="text-center mt-5"
+          v-if="
+            !error && (loader || searchBox.isLoadingResults || !modulesList)
+          "
+        >
+          <div class="spinner-border" role="status">
+            <span class="sr-only">Loading...</span>
           </div>
+          <div style="margin-bottom: 100vh"></div>
+        </div>
 
         <!-- search results -->
         <div
@@ -460,22 +546,25 @@
                   ></customLink>
                 </div>
 
-                <div class="search-item__description-wrapper"
-                     v-if="result.highlights.length > 0">
+                <div
+                  class="search-item__description-wrapper"
+                  v-if="result.highlights.length > 0"
+                >
                   <div
                     class="search-item__description"
                     v-for="(highlight, index) in result.highlights"
-                    :key="index + highlight.fieldIdentifier">
+                    :key="index + highlight.fieldIdentifier"
+                  >
                     <span class="search-item__description__label">
                       {{ getPropertyLabel(highlight.fieldIdentifier) }}
                     </span>
                     <span
                       class="search-item__description__highlight"
-                      v-html="highlight.highlightedText">
+                      v-html="highlight.highlightedText"
+                    >
                     </span>
                   </div>
                 </div>
-
               </div>
             </div>
           </div>
@@ -532,7 +621,10 @@
           </div>
         </div>
 
-        <div class="container" v-if="!searchBox.selectedData || !searchBox.selectedData.isSearch">
+        <div
+          class="container"
+          v-if="!searchBox.selectedData || !searchBox.selectedData.isSearch"
+        >
           <div class="row">
             <!-- SHOW ITEM -->
             <div class="col-md-12 col-lg-12 px-0 ontology-item" v-if="data">
@@ -1070,7 +1162,6 @@
             </div>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -1461,6 +1552,7 @@ export default {
       this.searchBox.selectedData = null;
       this.searchBox.inputValue = '';
       this.$refs.searchBoxInput2.search = '';
+      this.$refs.searchBoxInput.search = '';
     },
     searchResultClicked() {
       this.$root.ontologyRouteIsUpdating = true;
@@ -1625,6 +1717,7 @@ export default {
       const searchQuery = decodeURI(this.$route.query.searchBoxQuery);
       this.searchBox.inputValue=searchQuery;
       this.$refs.searchBoxInput2.search=searchQuery;
+      this.$refs.searchBoxInput.search=searchQuery;
       this.handleSearchBoxQuery(searchQuery);
       this.$nextTick(()=>{
         this.scrollToOntologyViewerTopOfContainer();


### PR DESCRIPTION
issue: https://github.com/edmcouncil/html-pages/issues/147
User can now configure search in mobile version of the website. Search also behaves the same as desktop version (search with loupe icon and search term is preserved after search).

![image](https://user-images.githubusercontent.com/87621210/156882064-20ba23ea-45fd-45ce-b017-4ef3bd888f89.png)

