### PR TITLE
White logo in mobile view

### DIFF
--- a/fibo/src/components/Header.vue
+++ b/fibo/src/components/Header.vue
@@ -98,7 +98,7 @@
 <div class="container header  mobile-view">
     <nav class="navbar navbar-expand-lg navbar-light mobile-view">
       <a class="navbar-brand" href="https://edmcouncil.org" target="_blank">
-        <img id="logo-fibo" src="@/assets/img/logoWhite.png" />
+        <img id="logo-fibo" src="@/assets/img/logo.png" />
       </a>
       <button
         class="navbar-toggler"


### PR DESCRIPTION
issue: https://github.com/edmcouncil/html-pages/issues/151
Changed logo version from white to default one.

![image](https://user-images.githubusercontent.com/87621210/158553239-9d8e5020-9288-47e6-be42-17e4fd720fb9.png)
