### PR TITLE
No space beetween edge and module view in mobile view

### DIFF
--- a/fibo/src/styles/views/Ontology.scss
+++ b/fibo/src/styles/views/Ontology.scss
@@ -1028,6 +1028,11 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
     }
   }
 }
+.secondary-column--mobile {
+  .modules-list--mobile {
+    padding: 0px 15px;
+  }
+}
 
 .ontology-item {
   .row {

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -269,7 +269,7 @@
         </div>
 
         <!-- mobile multiselects -->
-        <div class="container px-0 mb-2 d-lg-none">
+        <div class="secondary-column--mobile container px-0 mb-2 d-lg-none">
           <div
             class="
               secondary-column__versions secondary-column__versions--mobile
@@ -346,7 +346,7 @@
             </div>
           </div>
 
-          <ul v-if="display_modules" class="modules-list list-unstyled">
+          <ul v-if="display_modules" class="modules-list modules-list--mobile list-unstyled">
             <module-tree
               :item="item"
               v-for="item in modulesList"


### PR DESCRIPTION
issue: https://github.com/edmcouncil/html-pages/issues/152

Modules list is now aligned with the box.

![image](https://user-images.githubusercontent.com/87621210/158556568-d5050c26-1cf3-4f7e-8621-b7a1501c32f5.png)
