### PR TITLE
Unstable display of parameterized values

### DIFF
--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -1297,6 +1297,7 @@ export default {
     async fetchData(iri) {
       if (iri) {
         this.loader = true;
+        this.data = null;
         try {
           const query = `${this.ontologyServer}?iri=${iri}`;
           const result = await getEntity(query);

--- a/idmp/src/views/Ontology.vue
+++ b/idmp/src/views/Ontology.vue
@@ -1379,6 +1379,7 @@ export default {
     async fetchData(iri) {
       if (iri) {
         this.loader = true;
+        this.data = null;
         try {
           const query = `${this.ontologyServer}?iri=${iri}`
           const result = await getEntity(query);


### PR DESCRIPTION
Fixes: #186 
Clearing old ontology data before fetching a new entity each time seems to solve the problem. After testing the problem was gone for me after implementing this change.