### PR TITLE
Add 'Report a problem' button to auto and idmp sites

### DIFF
--- a/auto/src/styles/views/Ontology.scss
+++ b/auto/src/styles/views/Ontology.scss
@@ -675,11 +675,9 @@
       float: right;
       margin-top: 40px;
       margin-left: 10px;
-      background: rgba(0, 0, 0, 0.8);
       border-radius: 2px;
       padding: 5px 15px;
       border: none;
-      color: rgba(255, 255, 255, 0.9);
       text-decoration: none;
       font-family: Inter;
       font-style: normal;
@@ -687,14 +685,6 @@
       font-size: 14px;
       line-height: 20px;
       letter-spacing: 0.01em;
-      transition: background 0.2s;
-
-      &:hover{
-        background: $link-active-color;
-      }
-      &:active{
-        background: $link-hover-color;
-      }
     }
 
     h5 {

--- a/auto/src/views/Ontology.vue
+++ b/auto/src/views/Ontology.vue
@@ -356,6 +356,19 @@
                 <div class="col-md-12 ontology-item__header">
                   <div class="card">
                     <div class="card-body">
+                      <!-- report a problem -->
+                      <button
+                        type="button"
+                        class="btn normal-button btn-report-a-problem"
+                        v-if="
+                          !data.iri.startsWith('http://') &&
+                          !(this.$route.query && this.$route.query.version)
+                        "
+                        @click="githubNewIssue()"
+                      >
+                        Report a problem
+                      </button>
+
                       <!-- maturity alert -->
                       <div
                         class="alert alert-primary alert-maturity"
@@ -866,15 +879,6 @@ export default {
         window.scrollTo(0, scrollTop);
         this.$root.ontologyRouteIsUpdating = false;
       },
-      githubNewIssueDetails() {
-        const ontologyQuery = this.data.iri.replace('https://spec.edmcouncil.org/fibo/ontology/', '');
-        const label = ontologyQuery.substring(0, ontologyQuery.indexOf('/'));
-        return {
-          label,
-          title: `Problem with ${this.data.label.toUpperCase()}`,
-          body: `Resource URL:\n${this.data.iri}`,
-        };
-      },
     };
   },
   mounted() {
@@ -884,7 +888,6 @@ export default {
     if (this.$route.params && this.$route.params[1]) {
       const ontologyQuery = window.location.pathname.replace('/auto/ontology/', '');
       queryParam = `https://spec.edmcouncil.org/auto/ontology/${ontologyQuery}`;
-      // this.githubNewIssue.title = this.githubNewIssue.titleTemplate.replace('<LABEL>', this.githubNewIssue.label);
     } else if (this.$route.query && this.$route.query.query) {
       queryParam = encodeURIComponent(this.$route.query.query)+encodeURIComponent(this.$route.hash) || "";
     }
@@ -1186,7 +1189,23 @@ export default {
       let newNode = {'value': parts[0] ,'children':[]};
       treeNode.push(newNode);
       this.getTreeFromList(parts.splice(1,parts.length), newNode.children);
-    }
+    },
+    githubNewIssue() {
+      const ontologyQuery = this.data.iri.replace('https://spec.edmcouncil.org/auto/ontology/', '');
+      const label = ontologyQuery.substring(0, ontologyQuery.indexOf("/"));
+      const details = {
+        label,
+        title: `Problem with ${this.data.label.toUpperCase()}`,
+        body: `Resource URL:\n${this.data.iri}`,
+      };
+      const url =  `https://github.com/edmcouncil/auto/issues/new` +
+        `?labels=${encodeURI(details.label)}` +
+        `&template=issue.md` +
+        `&title=${encodeURI(details.title)}` +
+        `&body=${encodeURI(details.body)}`;
+
+      window.open(url, '_blank');
+    },
   },
   computed: {
     ...mapState({

--- a/fibo/src/styles/views/Ontology.scss
+++ b/fibo/src/styles/views/Ontology.scss
@@ -1026,11 +1026,9 @@
       float: right;
       margin-top: 40px;
       margin-left: 10px;
-      background: rgba(0, 0, 0, 0.8);
       border-radius: 2px;
       padding: 5px 15px;
       border: none;
-      color: rgba(255, 255, 255, 0.9);
       text-decoration: none;
       font-family: Inter;
       font-style: normal;
@@ -1038,14 +1036,6 @@
       font-size: 14px;
       line-height: 20px;
       letter-spacing: 0.01em;
-      transition: background 0.2s;
-
-      &:hover{
-        background: $link-active-color;
-      }
-      &:active{
-        background: $link-hover-color;
-      }
     }
 
     h5 {

--- a/fibo/src/views/Ontology.vue
+++ b/fibo/src/views/Ontology.vue
@@ -679,25 +679,18 @@
                   <div class="card">
                     <div class="card-body">
                       <!-- report a problem -->
-                      <a
+                      <button
+                        type="button"
+                        class="btn normal-button btn-report-a-problem"
                         v-if="
                           !data.iri.startsWith('http://') &&
                           !(this.$route.query && this.$route.query.version)
                         "
-                        class="btn-report-a-problem"
-                        target="_blank"
-                        :href="
-                          `https://github.com/edmcouncil/fibo/issues/new` +
-                          `?labels=${encodeURI(
-                            githubNewIssueDetails().label
-                          )}` +
-                          `&template=issue.md` +
-                          `&title=${encodeURI(githubNewIssueDetails().title)}` +
-                          `&body=${encodeURI(githubNewIssueDetails().body)}`
-                        "
+                        @click="githubNewIssue()"
                       >
                         Report a problem
-                      </a>
+                      </button>
+
                       <!-- maturity alert -->
                       <div class="ontology-item__header__status">
                         <div
@@ -1212,18 +1205,6 @@ export default {
         window.scrollTo(0, scrollTop);
         this.$root.ontologyRouteIsUpdating = false;
       },
-      githubNewIssueDetails() {
-        const ontologyQuery = this.data.iri.replace(
-          "https://spec.edmcouncil.org/fibo/ontology/",
-          ""
-        );
-        const label = ontologyQuery.substring(0, ontologyQuery.indexOf("/"));
-        return {
-          label,
-          title: `Problem with ${this.data.label.toUpperCase()}`,
-          body: `Resource URL:\n${this.data.iri}`,
-        };
-      },
     };
   },
   mounted() {
@@ -1233,7 +1214,6 @@ export default {
     if (this.$route.params && this.$route.params[1]) {
       const ontologyQuery = window.location.pathname.replace("/fibo/ontology/", "");
       queryParam = `https://spec.edmcouncil.org/fibo/ontology/${ontologyQuery}`;
-      // this.githubNewIssue.title = this.githubNewIssue.titleTemplate.replace('<LABEL>', this.githubNewIssue.label);
     } else if (this.$route.query && this.$route.query.query) {
       queryParam = encodeURI(this.$route.query.query)+encodeURI(this.$route.hash) || "";
     }
@@ -1690,6 +1670,25 @@ export default {
       let newNode = { value: parts[0], children: [] };
       treeNode.push(newNode);
       this.getTreeFromList(parts.splice(1, parts.length), newNode.children);
+    },
+    githubNewIssue() {
+      const ontologyQuery = this.data.iri.replace(
+        "https://spec.edmcouncil.org/fibo/ontology/",
+        ""
+      );
+      const label = ontologyQuery.substring(0, ontologyQuery.indexOf("/"));
+      const details = {
+        label,
+        title: `Problem with ${this.data.label.toUpperCase()}`,
+        body: `Resource URL:\n${this.data.iri}`,
+      };
+      const url =  `https://github.com/edmcouncil/fibo/issues/new` +
+        `?labels=${encodeURI(details.label)}` +
+        `&template=issue.md` +
+        `&title=${encodeURI(details.title)}` +
+        `&body=${encodeURI(details.body)}`;
+
+      window.open(url, '_blank');
     },
   },
   computed: {

--- a/idmp/src/styles/views/Ontology.scss
+++ b/idmp/src/styles/views/Ontology.scss
@@ -1026,11 +1026,9 @@
       float: right;
       margin-top: 40px;
       margin-left: 10px;
-      background: rgba(0, 0, 0, 0.8);
       border-radius: 2px;
       padding: 5px 15px;
       border: none;
-      color: rgba(255, 255, 255, 0.9);
       text-decoration: none;
       font-family: Inter;
       font-style: normal;
@@ -1038,14 +1036,6 @@
       font-size: 14px;
       line-height: 20px;
       letter-spacing: 0.01em;
-      transition: background 0.2s;
-
-      &:hover{
-        background: $link-active-color;
-      }
-      &:active{
-        background: $link-hover-color;
-      }
     }
 
     h5 {

--- a/idmp/src/views/Ontology.vue
+++ b/idmp/src/views/Ontology.vue
@@ -678,6 +678,19 @@
                 <div class="col-md-12 ontology-item__header">
                   <div class="card">
                     <div class="card-body">
+                      <!-- report a problem -->
+                      <button
+                        type="button"
+                        class="btn normal-button btn-report-a-problem"
+                        v-if="
+                          data.iri.startsWith('https://spec.pistoiaalliance.org') &&
+                          !(this.$route.query && this.$route.query.version)
+                        "
+                        @click="githubNewIssue()"
+                      >
+                        Report a problem
+                      </button>
+
                       <!-- maturity alert -->
                       <div class="ontology-item__header__status">
                         <div
@@ -1203,7 +1216,6 @@ export default {
     if (this.$route.params && this.$route.params[1]) {
       const ontologyQuery = window.location.pathname.replace("/idmp/ontology/", "");
       queryParam = `https://spec.edmcouncil.org/idmp/ontology/${ontologyQuery}`;
-      // this.githubNewIssue.title = this.githubNewIssue.titleTemplate.replace('<LABEL>', this.githubNewIssue.label);
     } else if (this.$route.query && this.$route.query.query) {
       queryParam = encodeURIComponent(this.$route.query.query)+encodeURIComponent(this.$route.hash) || "";
     }
@@ -1636,7 +1648,26 @@ export default {
       let newNode = {'value': parts[0] ,'children':[]};
       treeNode.push(newNode);
       this.getTreeFromList(parts.splice(1,parts.length), newNode.children);
-    }
+    },
+    githubNewIssue() {
+      const ontologyQuery = this.data.iri.replace(
+        "https://spec.pistoiaalliance.org/idmp/ontology/",
+        ""
+      );
+      const label = ontologyQuery.substring(0, ontologyQuery.indexOf("/"));
+      const details = {
+        label,
+        title: `Problem with ${this.data.label.toUpperCase()}`,
+        body: `Resource URL:\n${this.data.iri}`,
+      };
+      const url =  `https://github.com/edmcouncil/idmp/issues/new` +
+        `?labels=${encodeURI(details.label)}` +
+        `&template=issue.md` +
+        `&title=${encodeURI(details.title)}` +
+        `&body=${encodeURI(details.body)}`;
+
+      window.open(url, '_blank');
+    },
   },
   computed: {
     ...mapState({


### PR DESCRIPTION
Closes: https://github.com/edmcouncil/html-pages/issues/220

---

Added the Report button to AUTO and IDMP.

@mereolog  IDMP's repository (https://github.com/edmcouncil/idmp) seems to be private, if someone doesn't have access they will see github 404 page not found. IDMP viewer assumes that user does have access to the repository.
In case of IDMP the button shows only if iri starts with "https://spec.pistoiaalliance.org/idmp/ontology/"

---

![image](https://user-images.githubusercontent.com/87621210/177536657-15f57837-2c96-4953-a049-086d41022b63.png)
