### PR TITLE
Create default failure page for all EDMC projects

### DIFF
--- a/idmp/src/App.vue
+++ b/idmp/src/App.vue
@@ -1,19 +1,29 @@
 <template>
-  <div id="app">
+  <div v-if="isConnected" id="app">
     <HeaderComponent></HeaderComponent>
     <router-view />
     <FooterComponent></FooterComponent>
+  </div>
+  <div v-else>
+    <ConnectionProblem></ConnectionProblem>
   </div>
 </template>
 <script>
 import HeaderComponent from '@/components/HeaderComponent.vue';
 import FooterComponent from '@/components/FooterComponent.vue';
+import ConnectionProblem from '@/components/ConnectionProblem.vue';
 
 export default {
   components: {
     HeaderComponent,
     FooterComponent,
+    ConnectionProblem,
   },
+  data() {
+    return {
+      isConnected: true,
+    }
+  }
 };
 </script>
 

--- a/idmp/src/components/ConnectionProblem.vue
+++ b/idmp/src/components/ConnectionProblem.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="connectionProblemScreen">
+    <header>
+      <a class="navbar-brand" href="https://edmcouncil.org" target="_blank">
+        <img id="edmc-logo" src="@/assets/img/edmc-logo.jpg" />
+      </a>
+    </header>
+    <article class="full-page">
+      <section class="blank">
+        <img src="@/assets/icons/warning.svg" alt="Warning image" />
+        <h1 class>Connection Failed</h1>
+        <p class="muted">Couldn't reach our servers, please try again later.</p>
+
+        <a href="https://spec.edmcouncil.org/">Return to homepage</a>
+      </section>
+    </article>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ConnectionProblem'
+}
+</script>
+
+<style lang="scss" scoped>
+.connectionProblemScreen {
+  background: rgba(0, 0, 0, 0.05);
+  text-align: center;
+  position: relative;
+  min-height: 100vh;
+  height: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  header {
+    #edmc-logo {
+      position: absolute;
+      left: 30px;
+      top: 20px;
+      width: 200px;
+    }
+  }
+
+  article {
+    padding-top: 60px;
+
+    h1 {
+      opacity: 0.8;
+    }
+  }
+
+  article img {
+    width: 60px;
+    opacity: 0.5;
+    padding-bottom: 50px;
+  }
+
+  &::before {
+    position: absolute;
+    content: "";
+    width: 0px;
+    height: 0px;
+    top: 45%;
+    left: 50%;
+    border-radius: 50px;
+    box-shadow: 0px 0px 230px 230px rgba(255, 0, 0, 0.08);
+  }
+}
+</style>


### PR DESCRIPTION
Closes: https://github.com/edmcouncil/html-pages/issues/222

Added connection fail page, located in idmp project:

![image](https://user-images.githubusercontent.com/87621210/178547136-bcc96c15-ebf6-4d70-a557-5e786672ce04.png)

The error page can be switched on and off with the "isConnected" variable in App.vue - which is currently hardcoded and awaitng to be used in the generalized page. To show error page it needs to be set to false (line 24 in App.vue).

![image](https://user-images.githubusercontent.com/87621210/178547538-eff5ddb6-07ae-413f-b8cf-2c651a578b42.png)
