### PR TITLE
New maturity levels display

### DIFF
--- a/general/components/ModuleTree.vue
+++ b/general/components/ModuleTree.vue
@@ -7,13 +7,14 @@
         @click="toggle"
       ></div>
       <div
-        v-if="this.item.maturityLevel.label !== 'NOT_SET'"
+        v-if="this.item.maturityLevel.label !== 'Not Set'"
         class="indicator-container"
         :class="{
-          provisionalIndicator: this.item.maturityLevel.label === 'PROVISIONAL',
-          informativeIndicator: this.item.maturityLevel.label === 'INFORMATIVE',
-          releaseIndicator: this.item.maturityLevel.label === 'RELEASE',
-          mixedIndicator: this.item.maturityLevel.label === 'MIXED',
+          provisionalIndicator: this.item.maturityLevel.label === 'Provisional' ||
+                                this.item.maturityLevel.label === 'Preliminary',
+          informativeIndicator: this.item.maturityLevel.label === 'Informative',
+          releaseIndicator: this.item.maturityLevel.label === 'Release',
+          mixedIndicator: this.item.maturityLevel.label === 'Mixed',
           indicator: true,
         }"
       ></div>

--- a/general/pages/_.vue
+++ b/general/pages/_.vue
@@ -729,12 +729,13 @@
                               class="alert alert-primary alert-maturity"
                               :class="{
                                 informative:
-                                  data.maturityLevel.label === 'INFORMATIVE',
+                                  data.maturityLevel.label === 'Informative',
                               }"
                               role="alert"
                               v-if="
-                                data.maturityLevel.label === 'INFORMATIVE' ||
-                                data.maturityLevel.label === 'PROVISIONAL'
+                                data.maturityLevel.label === 'Informative' ||
+                                data.maturityLevel.label === 'Provisional' ||
+                                data.maturityLevel.label === 'Preliminary'
                               "
                             >
                               This resource has maturity level
@@ -750,8 +751,9 @@
 
                           <div
                             v-if="
-                              data.maturityLevel.label === 'INFORMATIVE' ||
-                              data.maturityLevel.label === 'PROVISIONAL' ||
+                              data.maturityLevel.label === 'Informative' ||
+                              data.maturityLevel.label === 'Provisional' ||
+                              data.maturityLevel.label === 'Preliminary' ||
                               data.deprecated
                             "
                             class="clearfix"
@@ -762,13 +764,14 @@
                             class="card-title"
                             :class="{
                               'maturity-provisional':
-                                this.data.maturityLevel.label === 'PROVISIONAL',
+                                this.data.maturityLevel.label === 'Provisional' ||
+                                this.data.maturityLevel.label === 'Preliminary',
                               'maturity-informative':
-                                this.data.maturityLevel.label === 'INFORMATIVE',
+                                this.data.maturityLevel.label === 'Informative',
                               'maturity-production':
-                                this.data.maturityLevel.label === 'RELEASE',
+                                this.data.maturityLevel.label === 'Release',
                               'maturity-mixed':
-                                this.data.maturityLevel.label === 'MIXED',
+                                this.data.maturityLevel.label === 'Mixed',
                             }"
                           >
                             {{ data.label }}


### PR DESCRIPTION
closes: #253 

Changed maturity level names,
"Preliminary" maturity level is treated the same as "Informative" maturity level - yellow icon.

![image](https://user-images.githubusercontent.com/87621210/192545767-49d02d5c-361b-48e0-9d5a-8a588497981c.png)
