### PR TITLE
Copy button changes

### DIFF
--- a/general/assets/scss/Ontology.scss
+++ b/general/assets/scss/Ontology.scss
@@ -1140,6 +1140,7 @@
     .data-iri {
       margin: 0px 0px;
       padding: 0;
+      word-break: break-all;
     }
     // qname
     .qname {
@@ -1149,7 +1150,7 @@
     // copy url button
     .btn-copy-url {
       color: rgba(0, 0, 0, 0.8);
-      margin-top: 20px;
+      margin-top: 15px;
       margin-bottom: 40px;
       border: none;
       background: none;
@@ -1187,9 +1188,6 @@
       display: flex;
       flex-direction: column;
       align-items: flex-start;
-    }
-    .btn-copy-iri {
-      margin-top: -30px;
     }
     .card {
       background: none;

--- a/general/pages/_.vue
+++ b/general/pages/_.vue
@@ -791,17 +791,30 @@
                           <div class="url-buttons-container">
                             <CopyButton
                               :copyContent="data.iri"
-                              :text="'Copy URL'"
+                              :text="'Copy IRI'"
                             />
-
+                          </div>
+                          <h6
+                            class="card-subtitle data-iri"
+                            v-if="this.$route.query && this.$route.query.version &&
+                            data.iri && data.iri.startsWith(ontologyResourcesBaseUri)"
+                          >
+                            {{ this.ontologyResourcesBaseUri +
+                                this.$route.query.version +
+                                '/' +
+                                data.iri.replace(this.ontologyResourcesBaseUri, '') }}
+                          </h6>
+                          <div
+                            class="url-buttons-container"
+                            v-if="this.$route.query && this.$route.query.version &&
+                              data.iri.startsWith(ontologyResourcesBaseUri)"
+                          >
                             <CopyButton
-                              v-if="
-                                this.$route.query && this.$route.query.version
-                              "
                               :copyContent="
-                                data.iri +
-                                '?version=' +
-                                encodeURI(this.$route.query.version)
+                                this.ontologyResourcesBaseUri +
+                                this.$route.query.version +
+                                '/' +
+                                data.iri.replace(this.ontologyResourcesBaseUri, '')
                               "
                               :text="'Copy versioned IRI'"
                               class="btn-copy-iri"


### PR DESCRIPTION
closes: #267 

Versioned IRI is now displayed when version is selected. The content of "Copy versioned IRI" button was changed to follow a different pattern:

![image](https://user-images.githubusercontent.com/87621210/196160434-7477eee1-1ef9-420f-a520-925ea9777437.png)
