### PR TITLE
Link underline placement

### DIFF
--- a/general/assets/scss/global.scss
+++ b/general/assets/scss/global.scss
@@ -21,6 +21,7 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
 * {
   box-sizing: border-box;
   font-family: Inter;
+  text-underline-position: under;
 }
 
 // Common elements


### PR DESCRIPTION
closes: #296 

Changed css rule for underline position. Before (left) and after (right):

![image](https://user-images.githubusercontent.com/87621210/202742091-06c9815d-06a9-4a0d-a470-ca54ba1c4595.png)
