### PR TITLE
Glossary items shown as a table

### DIFF
--- a/general/assets/scss/Ontology.scss
+++ b/general/assets/scss/Ontology.scss
@@ -902,12 +902,13 @@
 }
 
 .secondary-column {
-  margin-top: 40px;
+  // margin-top: 40px;
   padding: 0px;
 
   .module-tree {
     min-width: 285px;
-    margin-bottom: 40px;
+    padding-top: 40px;
+    padding-bottom: 40px;
 
     .modules-list {
       margin: 20px 0 0 20px;
@@ -949,80 +950,7 @@
 
     .card-content {
       margin-bottom: 60px;
-      background: rgba(0, 0, 0, 0.05);
       border-radius: 2px;
-      padding: 40px 30px 0 30px;
-    }
-
-    dt {
-      font-style: normal;
-      font-weight: bold;
-      font-size: 18px;
-      line-height: 30px;
-      text-transform: capitalize;
-
-      margin: 0;
-      padding: 0;
-    }
-
-    dd {
-      font-family: Inter;
-      font-style: normal;
-      font-weight: normal;
-      font-size: 18px;
-      line-height: 30px;
-
-      margin: 15px 0 40px 0;
-      padding: 0;
-
-      .see-less-btn,
-      .see-more-btn {
-        margin-top: 15px;
-      }
-
-      ul:not(.animated-list) > li:first-child {
-        margin-top: 0px;
-      }
-
-      ul {
-        margin-bottom: 0;
-        padding-left: 10px;
-
-        .see-less-btn,
-        .see-more-btn {
-          margin-top: 10px;
-        }
-
-        & > li {
-          margin-top: 15px;
-          background: url("@/assets/icons/dot.svg") no-repeat 0px 3px;
-          list-style: none;
-          padding: 0px 0px 0px 34px;
-
-          &.has-list {
-            background: url("@/assets/icons/triangle-down.svg") no-repeat 0px
-              3px;
-          }
-
-          ul {
-            padding-left: 20px;
-          }
-
-          li {
-            margin-top: 10px !important;
-            background: none;
-            list-style: disc;
-            padding: 0 0 0 5px;
-
-            &::marker {
-              color: rgba(0, 0, 0, 0.8);
-            }
-          }
-        }
-      }
-      a {
-        text-decoration: underline;
-      }
     }
   }
   a {
@@ -1576,59 +1504,6 @@
       h5 {
         font-size: 20px;
         line-height: 30px;
-      }
-      .card-content {
-        background: rgba(0, 0, 0, 0.05);
-        padding: 40px 30px 0 30px;
-      }
-      dt {
-        font-size: 16px;
-        line-height: 24px;
-      }
-      dd {
-        font-size: 16px;
-        line-height: 24px;
-        a {
-          text-decoration: underline;
-        }
-        .see-more-btn-wrapper {
-          margin-left: 0;
-        }
-        ul {
-          padding-left: 0px;
-
-          .see-less-btn,
-          .see-more-btn {
-            margin-left: -11px;
-          }
-
-          & > li {
-            margin-top: 15px;
-            background: url("@/assets/icons/dot.svg") no-repeat 0px 0px;
-            list-style: none;
-            padding: 0px 0px 0px 29px;
-
-            &.has-list {
-              background: url("@/assets/icons/triangle-down.svg") no-repeat 0px
-                0px;
-            }
-
-            ul {
-              padding-left: 15px;
-            }
-
-            li {
-              margin-top: 10px !important;
-              background: none;
-              list-style: disc;
-              padding: 0 0 0 5px;
-
-              &::marker {
-                color: rgba(0, 0, 0, 0.8);
-              }
-            }
-          }
-        }
       }
     }
 

--- a/general/components/Ontology/PropertiesList.vue
+++ b/general/components/Ontology/PropertiesList.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="show-more-list">
     <div v-if="list.length > 1">
-      <ul>
+      <ul :class="{'is-show-more': list.length > limit}">
         <li
           v-for="field in list.slice(0, limit)"
           :key="field.id"
           :class="{'has-list': field.hasList}"
           ref="sliceList"
+          class="top-level top-level--list"
         >
           <component
             :is="field.type"
@@ -18,12 +19,12 @@
       </ul>
       <b-collapse :id="`${sectionId}-collapse`" v-model="expanded">
         <transition name="list">
-          <ul class="animated-list" :id="sectionId" v-show="expanded">
+          <ul class="animated-list" :id="sectionId" v-show="expanded" :class="{'is-show-more': list.length > limit}">
             <li
               v-for="(field, index) in list.slice(limit)"
               :key="field.id"
               :class="{'has-list': field.hasList}"
-              class="list-item"
+              class="list-item top-level top-level--list"
               ref="collapsedList"
             >
               <component
@@ -48,6 +49,7 @@
       :entityMaping="field.entityMaping"
       :class="{'has-list': field.hasList}"
       v-bind="field"
+      class="top-level top-level--single"
     ></component>
 
     <div class="see-more-btn-wrapper" v-if="list.length > limit">
@@ -127,10 +129,10 @@ export default {
     },
     checkHasList(item) {
       if (item.type === "AXIOM" && item.fullRenderedString?.includes("<br />")) {
-        item.hasList = true
+        item.hasList = true;
       }
       else if (item.type === "STRING" && item.value?.includes("\n")) {
-        item.hasList = true
+        item.hasList = true;
       }
     }
   },
@@ -145,9 +147,5 @@ export default {
 <style lang="scss" scoped>
 .animated-list {
   overflow: hidden;
-}
-
-.see-more-btn-wrapper {
-  margin-left: 10px;
 }
 </style>

--- a/general/components/Ontology/ResourceSection.vue
+++ b/general/components/Ontology/ResourceSection.vue
@@ -3,20 +3,28 @@
     <div class="card-body">
       <h5
         class="card-title section-title"
-        :class="{'section-collapse': collapsed}"
+        :class="{ 'section-collapse': collapsed }"
         @click="toggleCollapsed"
       >
         {{ sectionName }}
       </h5>
       <div class="card-content">
         <dl
-          class="row"
+          class="row content-item"
           v-for="(property, name) in section"
           :key="name"
         >
-          <dt class="col-sm-12">{{ name }}</dt>
-          <dd class="col-sm-12">
-            <PropertiesList :list="property" :limit="5" :sectionId="'section_'+sectionName+'_'+sectionIndex+'_'+name" />
+          <dt class="col-md-3 col-sm-12">
+            <div class="content-item__title sticky-top">{{ name }}</div>
+          </dt>
+          <dd class="col-md-9 col-sm-12">
+            <PropertiesList
+              :list="property"
+              :limit="5"
+              :sectionId="
+                'section_' + sectionName + '_' + sectionIndex + '_' + name
+              "
+            />
           </dd>
         </dl>
       </div>
@@ -50,3 +58,196 @@ export default {
 };
 </script>
 
+<style lang="scss">
+.card-body .card-content .content-item {
+  background: rgba(0, 0, 0, 0.05);
+  padding: 0px;
+  margin-bottom: 6px;
+
+  dt {
+    font-style: normal;
+    font-weight: normal;
+    font-size: 18px;
+    line-height: 30px;
+    color: map-get($colors-map, "black-60");
+
+    margin: 0;
+    padding: 0 20px 0 20px;
+
+    border-right: 2px solid white;
+
+    .content-item__title {
+      padding-top: 10px;
+      padding-bottom: 10px;
+    }
+  }
+  dd {
+    font-style: normal;
+    font-weight: normal;
+    font-size: 18px;
+    line-height: 30px;
+
+    margin: 0;
+    padding: 0;
+
+    .see-more-btn-wrapper {
+      padding: 10px 0 10px 12px;
+    }
+    .see-less-btn,
+    .see-more-btn {
+      margin-top: 0;
+    }
+
+    .top-level {
+      padding: 10px 20px 10px 20px;
+      display: block;
+      border-bottom: 2px solid white;
+      background-repeat: no-repeat;
+      background-size: 24px 24px;
+      background-position: 12px 12px;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &.top-level--list {
+        padding: 10px 20px 10px 44px;
+        background-image: url("@/assets/icons/dot.svg");
+      }
+
+      &.has-list {
+        padding: 10px 20px 10px 44px;
+        background-image: url("@/assets/icons/triangle-down.svg");
+      }
+    }
+
+    ul:not(.animated-list) > li:first-child {
+      margin-top: 0px;
+    }
+
+    ul {
+      margin-bottom: 0;
+      padding-left: 0px;
+
+      &.is-show-more {
+        border-bottom: 2px solid white;
+      }
+
+      .see-less-btn,
+      .see-more-btn {
+        margin-top: 10px;
+        margin-left: -7px;
+      }
+
+      & > li {
+        list-style: none;
+
+        ul {
+          padding-left: 20px;
+          border: none;
+        }
+
+        li {
+          margin-top: 10px !important;
+          background: none;
+          list-style: disc;
+          padding: 0 0 0 5px;
+
+          &::marker {
+            color: rgba(0, 0, 0, 0.8);
+          }
+        }
+      }
+    }
+    a {
+      text-decoration: underline;
+    }
+  }
+}
+
+// --------------------------
+// Mobile
+// --------------------------
+@media (max-width: 991px) {
+  .card-body .card-content .content-item {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-bottom: 5px;
+
+    dt {
+      font-style: normal;
+      font-weight: bold;
+      font-size: 16px;
+      line-height: 24px;
+      border-right: none;
+      color: black;
+
+      .content-item__title {
+        padding-bottom: 10px;
+      }
+    }
+    dd {
+      padding-left: 10px;
+      font-size: 16px;
+      line-height: 24px;
+      a {
+        text-decoration: underline;
+      }
+      .see-more-btn-wrapper {
+        margin-left: 0;
+      }
+      ul {
+        padding-left: 0px;
+        padding-bottom: 10px;
+        &.is-show-more {
+          border-bottom: none;
+        }
+
+        .see-less-btn,
+        .see-more-btn {
+          margin-left: -7px;
+        }
+
+        .top-level {
+          padding: 5px 20px 5px 40px;
+          display: block;
+          border-bottom: none;
+          background-image: url("@/assets/icons/dot.svg");
+          background-repeat: no-repeat;
+          background-size: 24px 24px;
+          background-position: 8px 6px;
+
+          &:last-child {
+            border-bottom: none;
+          }
+
+          &.has-list {
+            background-image: url("@/assets/icons/triangle-down.svg");
+          }
+        }
+
+        & > li {
+          background: url("@/assets/icons/dot.svg") no-repeat 0px 0px;
+          list-style: none;
+          padding: 0px 0px 0px 30px;
+
+          ul {
+            padding-left: 20px;
+          }
+
+          li {
+            margin-top: 10px !important;
+            background: none;
+            list-style: disc;
+            padding: 0 0 0 5px;
+
+            &::marker {
+              color: rgba(0, 0, 0, 0.8);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+</style>

--- a/general/components/chunks/AXIOM.vue
+++ b/general/components/chunks/AXIOM.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="!isShowMore">
     <component :is="processedTitle"></component>
-    <ul>
+    <ul v-if="processedList.length > 0">
       <li
         v-for="(item, index) in processedList"
         :key="`${processedTitle}_${item}_${index}`"
@@ -153,9 +153,5 @@ export default {
 <style lang="scss" scoped>
 .animated-list {
   overflow: hidden;
-}
-
-.see-more-btn, .see-less-btn {
-  margin-left: -6px;
 }
 </style>

--- a/general/components/chunks/STRING.vue
+++ b/general/components/chunks/STRING.vue
@@ -122,8 +122,4 @@ export default {
 .animated-list {
   overflow: hidden;
 }
-
-.see-more-btn, .see-less-btn {
-  margin-left: -6px;
-}
 </style>


### PR DESCRIPTION
closes: #298 

Changed the way properties of resources are displayed. The items are separated into two columns - title and content. The titles follow screen viewport so that they are always visible when scrolling. The spacing of the table can be changed/adjusted further if needed.
Currently there is 2px gap for vertical seperation of title and top level list items (as seen on screen 2 and 3), and a 6px gap between different properties so that they don't blend together too much.

Resource properties displayed as table examples:
---
![image](https://user-images.githubusercontent.com/87621210/204028427-504a8a14-ee89-4005-9f29-44168ddc0253.png)
---
![image](https://user-images.githubusercontent.com/87621210/204028541-7d542768-c0a1-43fb-ad4d-493f6f63a86b.png)
---
![image](https://user-images.githubusercontent.com/87621210/204028955-6da18c74-172c-4fc3-9802-19a691a820d0.png)
---


