### PR TITLE
Stop infinite diagram expansion

### DIFF
--- a/general/components/Ontology/GraphGuide.vue
+++ b/general/components/Ontology/GraphGuide.vue
@@ -634,7 +634,7 @@
       @closeEvent="closeHandler()"
       @returnEvent="returnHandler()"
     >
-      <template v-slot:label> User Guide: Sorting </template>
+      <template v-slot:label> User Guide: Configuration </template>
       <template v-slot:content>
         <article>
           <div class="see-also-box">

--- a/general/components/Ontology/GraphVisualization.vue
+++ b/general/components/Ontology/GraphVisualization.vue
@@ -151,7 +151,7 @@
             Child nodes not found in "{{ alert.source }}".
           </p>
           <p v-if="alert.type=='duplicate'">
-            Node "{{ alert.source }}" is expanded already.
+            Node "{{ alert.source }}" is already expanded.
           </p>
         </div>
       </div>

--- a/general/components/Ontology/GraphVisualization.vue
+++ b/general/components/Ontology/GraphVisualization.vue
@@ -148,7 +148,10 @@
       <div class="alerts-container">
         <div class="node-alert" v-for="alert in alerts" :key="alert.id">
           <p v-if="alert.type=='noChildren'">
-            Child nodes not found in {{ alert.source }}.
+            Child nodes not found in "{{ alert.source }}".
+          </p>
+          <p v-if="alert.type=='duplicate'">
+            Node "{{ alert.source }}" is expanded already.
           </p>
         </div>
       </div>
@@ -419,8 +422,8 @@ export default {
         source
       });
       setTimeout(() => {
-        this.alerts.pop();
-      }, 2500);
+        this.alerts.shift();
+      }, 3500);
     },
     sortAZ() {
       this.ontograph.sort("az");
@@ -555,6 +558,7 @@ export default {
   padding: 15px;
   display: flex;
   flex-direction: column;
+  pointer-events: none;
 
   p {
     font-family: 'Inter';
@@ -562,6 +566,31 @@ export default {
     font-weight: 400;
     font-size: 18px;
     line-height: 30px;
+
+    color: map-get($colors-map, "black-80");
+    background: map-get($colors-map, "white");
+    width: max-content;
+    border-radius: 2px;
+    padding: 5px 15px;
+    margin-top: 10px;
+
+    box-shadow: 0px 5px 20px -5px rgba(8, 84, 150, 0.15);
+  }
+
+  .node-alert {
+    animation-name: alert-appear;
+    animation-duration: 0.3s;
+  }
+}
+
+@keyframes alert-appear {
+  from {
+    opacity: 0;
+    transform: translateX(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0px);
   }
 }
 

--- a/general/helpers/ontograph.js
+++ b/general/helpers/ontograph.js
@@ -488,19 +488,7 @@ export class Ontograph {
       });
     }
 
-    this.links = this.root.links();
-    this.nodes = this.root.descendants();
-
-    this.simulation.stop();
-    this.updateSimulation();
-    this.initLinks();
-    this.initNodes();
-
-    if (this.layout === "tree") this.toTree();
-    else if (this.layout === "clusterTree") this.toClusterTree();
-    else if (this.layout === "radial") this.toRadial();
-    else if (this.layout === "clusterRadial") this.toClusterRadial();
-    else if (this.layout === "force") this.toForce();
+    this.filter(this.filters);
   }
 
   filter(filters) {

--- a/general/helpers/ontograph.js
+++ b/general/helpers/ontograph.js
@@ -564,6 +564,13 @@ export class Ontograph {
     }
     // if node contains expanded children hide them
     else if (d.children) {
+      // disable collapsing for root node
+      if (!d.parent) {
+        this.blurHighlight();
+        this.isShifting = null;
+        return;
+      }
+
       d._children = d.children;
       d.children = null;
     }

--- a/general/helpers/ontograph.js
+++ b/general/helpers/ontograph.js
@@ -2,10 +2,16 @@ import * as d3 from "d3";
 
 export class Ontograph {
   layout = "force";
-  transitionSpeed = 500;
+  transitionSpeed = 400;
   mouseoverTransitionSpeed = 300;
   distance = 50;
   alertId = 0;
+  filters = {
+    external: true,
+    internal: true,
+    optional: true,
+    required: true,
+  };
 
   constructor(data, target, navigationHandler, alertHandler, graphServer) {
     this.target = target;
@@ -21,6 +27,11 @@ export class Ontograph {
       .stratify()
       .id((d) => d.id)
       .parentId((d) => d.from)(this.parsedNodes);
+
+    this.root.each((node) => {
+      if (node.children)
+        node._totalChildren = node.children;
+    });
 
     this.links = this.root.links();
     this.nodes = this.root.descendants();
@@ -189,7 +200,7 @@ export class Ontograph {
 
       function dragStarted(event, d) {
         if (that.layout !== "force") return;
-        if (!event.active) simulation.alphaTarget(0.6).restart();
+        if (!event.active) simulation.alphaTarget(0.3).restart();
         d.fx = d.x;
         d.fy = d.y;
         setTimeout(() => {
@@ -227,7 +238,7 @@ export class Ontograph {
             .attr("class", "node")
             .attr(
               "transform",
-              (d) => `translate(${at ? at.x : d.x},${at ? at.y : d.y})`
+              (d) => `translate(${at ? at.x : d.parent ? d.parent.x : d.x},${at ? at.y : d.parent ? d.parent.y : d.y})`
             );
 
           newNode
@@ -410,7 +421,9 @@ export class Ontograph {
         d3
           .forceManyBody()
           .strength(
-            (d) => ((-this.distance * 30) * (d.parent ? 1 : 5)) / (d.children ? 0.5 : 3)
+            (d) =>
+              (-this.distance * 30 * (d.parent ? 1 : 5)) /
+              (d.children ? 0.5 : 3)
           )
       )
       .force("center", d3.forceCenter().strength(0.2))
@@ -456,15 +469,23 @@ export class Ontograph {
     }, this.transitionSpeed);
 
     if (type === "az") {
-      this.root.sort((a, b) =>
-        d3.ascending(a.data.nodeLabel, b.data.nodeLabel)
-      );
+      this.root.each(d => {
+        d._totalChildren?.sort((a, b) =>
+          d3.ascending(a.data.nodeLabel, b.data.nodeLabel)
+        );
+      });
     } else if (type === "height") {
-      this.root.sort((a, b) => d3.descending(a.height, b.height));
+      this.root.each(d => {
+        d._totalChildren?.sort((a, b) => d3.descending(a.height, b.height));
+      });
     } else if (type === "type") {
-      this.root.sort((a, b) => d3.descending(a.data.type, b.data.type));
+      this.root.each(d => {
+        d._totalChildren?.sort((a, b) => d3.descending(a.data.type, b.data.type));
+      });
     } else if (type === "inherited") {
-      this.root.sort((a, b) => d3.descending(a.data.dashes, b.data.dashes));
+      this.root.each(d => {
+        d._totalChildren?.sort((a, b) => d3.descending(a.data.dashes, b.data.dashes));
+      });
     }
 
     this.links = this.root.links();
@@ -486,41 +507,45 @@ export class Ontograph {
     this.filters = filters;
     let { external, internal, optional, required } = filters;
 
-    let filteredData = this.parsedNodes.filter((n) => {
-      if (n.type == "MAIN") return true;
+    this.root.each((d) => {
+      if(!d._totalChildren)
+        return;
 
-      if (n.dashes && !optional) return false;
-      if (!n.dashes && !required) return false;
-      if (n.type == "EXTERNAL" && !external) return false;
-      if (n.type == "INTERNAL" && !internal) return false;
+      if(d._children)
+        return;
 
-      return true;
-    });
+      let totalChildren = d._totalChildren;
 
-    // find abandoned edges
-    let repeat;
-    do {
-      repeat = false;
-      filteredData = filteredData.filter((n) => {
-        if (n.type == "MAIN") return true;
+      let remaining = [];
+      let filteredOut = [];
 
-        if (filteredData.find((f) => f.id == n.from)) return true;
-        else {
-          repeat = true;
-          return false;
+      totalChildren.forEach((child) => {
+        if (
+          (child.data.dashes && !optional) ||
+          (!child.data.dashes && !required) ||
+          (child.data.type == "EXTERNAL" && !external) ||
+          (child.data.type == "INTERNAL" && !internal)
+        ) {
+          filteredOut.push(child);
+          return;
         }
+
+        remaining.push(child);
       });
-    } while (repeat);
+
+      d.children = remaining;
+      d._children = null;
+      d._filtered = filteredOut;
+
+      if(d.children.length == 0) {
+        delete d.children;
+      }
+    });
 
     this.isShifting = null;
     this.isShifting = setTimeout(() => {
       this.isShifting = null;
     }, this.transitionSpeed);
-
-    this.root = d3
-      .stratify()
-      .id((d) => d.id)
-      .parentId((d) => d.from)(filteredData);
 
     this.links = this.root.links();
     this.nodes = this.root.descendants();
@@ -529,8 +554,6 @@ export class Ontograph {
     this.updateSimulation();
     this.initLinks();
     this.initNodes();
-
-    if (this.sortType) this.sort(this.sortType);
 
     if (this.layout === "tree") this.toTree();
     else if (this.layout === "clusterTree") this.toClusterTree();
@@ -558,14 +581,30 @@ export class Ontograph {
     }
     // if node has no saved children and height equal to 0 then fetch nodes
     else if (!d.height || d.height == 0) {
+      // check if node is a duplicate to avoid infinite loops
+      let tmp = d;
+      while (tmp.parent) {
+        tmp = tmp.parent;
+
+        if (
+          d.data.nodeIri === tmp.data.nodeIri &&
+          d.data.nodeLabel === tmp.data.nodeLabel
+        ) {
+          this.pushAlert("duplicate", d.data.nodeLabel);
+          this.isShifting = null;
+          this.blurHighlight();
+          return;
+        }
+      }
+
       try {
         // add loader
         this.svg
           .select(".nodes")
           .selectAll("g")
-          .data(this.nodes, n => n.data.id)
-          .filter(n => {
-              return n.data.id == d.data.id;
+          .data(this.nodes, (n) => n.data.id)
+          .filter((n) => {
+            return n.data.id == d.data.id;
           })
           .append("g")
           .attr("class", "node-loader")
@@ -574,7 +613,6 @@ export class Ontograph {
           .attr("fill", "none")
           .attr("stroke-width", 2)
           .attr("class", "node-loader__circle");
-
 
         // fetch children from server
         const domain = `${this.graphServer}?iri=${encodeURI(
@@ -594,9 +632,9 @@ export class Ontograph {
           this.svg
             .select(".nodes")
             .selectAll("g")
-            .data(this.nodes, n => n.data.id)
-            .filter(n => {
-                return n.data.id == d.data.id;
+            .data(this.nodes, (n) => n.data.id)
+            .filter((n) => {
+              return n.data.id == d.data.id;
             })
             .select(".node-loader")
             .remove();
@@ -610,9 +648,9 @@ export class Ontograph {
           this.svg
             .select(".nodes")
             .selectAll("g")
-            .data(this.nodes, n => n.data.id)
-            .filter(n => {
-                return n.data.id == d.data.id;
+            .data(this.nodes, (n) => n.data.id)
+            .filter((n) => {
+              return n.data.id == d.data.id;
             })
             .select(".node-loader")
             .remove();
@@ -639,6 +677,11 @@ export class Ontograph {
 
         d.children = childRoot.children;
 
+        d.each((node) => {
+          if (node.children)
+            node._totalChildren = node.children;
+        });
+
         // update all heights
         let tmp = d;
         while (tmp.parent?.height < tmp.height + 1) {
@@ -653,9 +696,9 @@ export class Ontograph {
       this.svg
         .select(".nodes")
         .selectAll("g")
-        .data(this.nodes, n => n.data.id)
-        .filter(n => {
-            return n.data.id == d.data.id;
+        .data(this.nodes, (n) => n.data.id)
+        .filter((n) => {
+          return n.data.id == d.data.id;
         })
         .select(".node-loader")
         .remove();
@@ -671,6 +714,8 @@ export class Ontograph {
       this.isShifting = null;
       this.blurHighlight();
     }, this.transitionSpeed);
+
+    this.filter(this.filters);
 
     if (this.layout === "tree") this.toTree();
     else if (this.layout === "clusterTree") this.toClusterTree();
@@ -951,7 +996,7 @@ export class Ontograph {
 
   toForce() {
     this.updateSimulation();
-    this.simulation.alpha(1).alphaTarget(0.5);
+    this.simulation.alpha(0.7).alphaTarget(0.5);
 
     this.node
       .selectAll("text")
@@ -963,7 +1008,7 @@ export class Ontograph {
 
     setTimeout(() => {
       this.simulation.alphaTarget(0);
-    }, 50);
+    }, 150);
   }
 
   center() {
@@ -985,7 +1030,9 @@ export class Ontograph {
       .duration(this.transitionSpeed)
       .call(
         this.zoomController.transform,
-        d3.zoomIdentity.translate(-midX * scale - controlPanelOffset / 2, -midY * scale).scale(scale)
+        d3.zoomIdentity
+          .translate(-midX * scale - controlPanelOffset / 2, -midY * scale)
+          .scale(scale)
       );
   }
 


### PR DESCRIPTION
closes: #302 

- Added notification when user attempts to expand a node that was expanded already in the same tree path,
- Fixed graph expanding not working when filters are applied,
- Filtering will not reset sorting order anymore,
- Improved graph notifications look,
- Fixed typo in "Configuration" user guide

![image](https://user-images.githubusercontent.com/87621210/205046805-b49b8d7b-2950-48fb-a719-da9d23a2bb9d.png)

![image](https://user-images.githubusercontent.com/87621210/205046887-3513e65d-1876-4a0b-aee1-4e9f20646e62.png)
