### PR TITLE
Restore link underline

### DIFF
--- a/general/assets/scss/global.scss
+++ b/general/assets/scss/global.scss
@@ -21,6 +21,7 @@ $normal-button-disabled-bg: rgba(0, 0, 0, 0.4);
 * {
   box-sizing: border-box;
   font-family: Inter;
+  text-underline-position: auto;
 }
 
 // Common elements


### PR DESCRIPTION
closes: #309 

Link underlines should use old styling now.