### PR TITLE
Add new error handling when sections is not recognized… 

### DIFF
--- a/general/helpers/meta.js
+++ b/general/helpers/meta.js
@@ -3,7 +3,7 @@ const linkLabelRegex = /\[([^\]]*?)\][\[\(].*?[\]\)]/g;
 const linkRegex = /~(.*?)~/g;
 
 export function prepareDescription(input){
-  if(!input) return "";
+  if(!input || input.length === 0) return "";
   var tmp = input
     .replace(headerRegex, "")
     .trim()

--- a/general/pages/index.vue
+++ b/general/pages/index.vue
@@ -72,12 +72,19 @@ export default {
 
     try {
       const response = await getStrapiSingleType(singleTypeName, populateParams);
-      const title = response.data.data.attributes.sections[0].title || process.env.VUE_ONTOLOGY_NAME;
+      if(response?.data?.data?.attributes?.sections == null)
+      {
+        console.error(`Page data(sections) is not recognized in the response from the server.
+        Error occurred while rendering page ${singleTypeName}.\n
+        Current server response:\n${response}`);
+        error({ statusCode: 503, message: "Service Unavailable" });
+      }
 
-      const description = (response.data.data.attributes.sections[0] != null && response.data.data.attributes.sections[0].items[0] != null) ?
-        prepareDescription(response.data.data.attributes.sections[0].items[0].text_content) : "";
+      const title = response?.data?.data?.attributes?.sections?.[0]?.title ?? process.env.VUE_ONTOLOGY_NAME;
+      const description = prepareDescription(response?.data?.data?.attributes?.sections?.[0]?.items?.[0]?.text_content ?? "");
+
       return {
-        page: response.data.data.attributes.sections,
+        page: response?.data?.data?.attributes.sections,
         title: title,
         description: description
       };

--- a/general/pages/index.vue
+++ b/general/pages/index.vue
@@ -84,7 +84,7 @@ export default {
       const description = prepareDescription(response?.data?.data?.attributes?.sections?.[0]?.items?.[0]?.text_content ?? "");
 
       return {
-        page: response?.data?.data?.attributes.sections,
+        page: response?.data?.data?.attributes?.sections,
         title: title,
         description: description
       };

--- a/general/pages/index.vue
+++ b/general/pages/index.vue
@@ -76,7 +76,7 @@ export default {
       {
         console.error(`Page data(sections) is not recognized in the response from the server.
         Error occurred while rendering page ${singleTypeName}.\n
-        Current server response:\n${response}`);
+        Current server response:\n`, response);
         error({ statusCode: 503, message: "Service Unavailable" });
       }
 

--- a/general/pages/page/_slug.vue
+++ b/general/pages/page/_slug.vue
@@ -89,7 +89,7 @@ export default {
       {
         console.error(`Page data(sections) is not recognized in the response from the server.
         Error occurred while rendering page ${slugName}.\n
-        Current server response:\n${response}`);
+        Current server response:\n`, response);
         error({ statusCode: 503, message: "Service Unavailable" });
       }
 

--- a/general/pages/page/_slug.vue
+++ b/general/pages/page/_slug.vue
@@ -85,10 +85,18 @@ export default {
         slugName
       );
 
-      const title = response.data.data[0].attributes.title || process.env.VUE_ONTOLOGY_NAME;
-      const description = prepareDescription(response.data.data[0].attributes.sections[0].text_content);
+      if(response?.data?.data?.[0]?.attributes?.sections == null)
+      {
+        console.error(`Page data(sections) is not recognized in the response from the server.
+        Error occurred while rendering page ${slugName}.\n
+        Current server response:\n${response}`);
+        error({ statusCode: 503, message: "Service Unavailable" });
+      }
+
+      const title = response?.data?.data?.[0]?.attributes?.title || process.env.VUE_ONTOLOGY_NAME;
+      const description = prepareDescription(response?.data?.data?.[0]?.attributes?.sections?.[0]?.text_content ?? "");
       return {
-        page: response.data.data[0].attributes.sections,
+        page: response?.data?.data?.[0]?.attributes?.sections,
         title: title,
         description: description
       };

--- a/general/pages/release-notes.vue
+++ b/general/pages/release-notes.vue
@@ -62,6 +62,15 @@ export default {
 
     try {
       const response = await getStrapiCollection(collectionTypeName, [], sortParams);
+
+      if(response?.data?.data == null)
+      {
+        console.error(`Page data(sections) is not recognized in the response from the server.
+        Error occurred while rendering page ${collectionTypeName}.\n
+        Current server response:\n${response}`);
+        error({ statusCode: 503, message: "Service Unavailable" });
+      }
+
       let responseData = response.data.data;
       let releaseTree = new Map();
       let releaseList = [];

--- a/general/pages/release-notes.vue
+++ b/general/pages/release-notes.vue
@@ -67,7 +67,7 @@ export default {
       {
         console.error(`Page data(sections) is not recognized in the response from the server.
         Error occurred while rendering page ${collectionTypeName}.\n
-        Current server response:\n${response}`);
+        Current server response:\n`, response);
         error({ statusCode: 503, message: "Service Unavailable" });
       }
 


### PR DESCRIPTION
Add new error handling when sections is not recognized in server response and display more useful data.

Fixes: #312 

Now when strapi returns an error it will be known in detail, previously we couldn't know the details of the problem.
If strapi returns incorrect data, a page 503 will be created like before, but Jenkins artifacts should contain information about an incorrect response.

Signed-off-by: dasawanaka <michal.19.daniel.96@gmail.com>