### PR TITLE
References to outboundClick removed from general

### DIFF
--- a/general/components/Articles/DownloadSection.vue
+++ b/general/components/Articles/DownloadSection.vue
@@ -17,7 +17,6 @@ export default {
   props: [ 'sectionItem' ],
   methods: {
     visit(url) {
-      this.outboundClick(url);
       const aElement = document.createElement("a");
       aElement.setAttribute("href", url);
       aElement.setAttribute("target", "_blank");

--- a/general/components/Articles/TableListSection.vue
+++ b/general/components/Articles/TableListSection.vue
@@ -39,7 +39,6 @@ export default {
   },
   computed: {
     visit(url) {
-      this.outboundClick(url);
       const aElement = document.createElement("a");
       aElement.setAttribute("href", url);
       aElement.setAttribute("target", "_blank");


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

This hot fix removes all references to the outboundClick function from general folder.