### PR TITLE
version list: use "/ontology/" endpoint instead of "/ontology/api/"

### DIFF
--- a/general/components/Articles/SerializationListSection.vue
+++ b/general/components/Articles/SerializationListSection.vue
@@ -243,7 +243,7 @@ export default {
     async fetchVersions() {
       try {
         const result = await getOntologyVersions(
-          `/${this.ontologyName}/ontology/api/`
+          `/${this.ontologyName}/ontology/`
         );
         const ontologyVersions = await result.json();
         this.ontologyVersionsDropdownData.data = ontologyVersions;

--- a/general/components/HeaderComponent.vue
+++ b/general/components/HeaderComponent.vue
@@ -236,6 +236,7 @@ header.website-header {
 
   #logo-fibo {
     width: 140px;
+    height: 40px;
   }
 }
 


### PR DESCRIPTION
closes: #325 

Updated products versions endpoint to use `/ontology/` instead of `/ontology/api/`.

Additional fix:

- Added explicit height of logo in case if a custom logo added with strapi config doesn't fit