### PR TITLE
Better header scaling for custom logos

### DIFF
--- a/general/components/HeaderComponent.vue
+++ b/general/components/HeaderComponent.vue
@@ -7,11 +7,11 @@
             <nav class="navbar navbar-expand navbar-light">
               <a
                 class="navbar-brand"
-                href="https://edmcouncil.org"
+                href="/"
                 target="_blank"
                 v-if="isCustomLogo"
               >
-                <img id="logo-fibo" :src="ontologyLogoUrl" />
+                <img id="ontology-logo" :src="ontologyLogoUrl" />
               </a>
               <a
                 class="navbar-brand"
@@ -19,7 +19,7 @@
                 target="_blank"
                 v-else
               >
-                <img id="logo-fibo" src="@/assets/img/logo.png" />
+                <img id="ontology-logo" src="@/assets/img/logo.png" />
               </a>
 
               <ul class="navbar-nav ml-auto align-items-center">
@@ -210,7 +210,6 @@ header.website-header {
   background-position: center;
   padding: 0;
   min-height: 480px;
-  max-height: 480px;
 
   display: flex;
   flex-direction: column;
@@ -229,14 +228,16 @@ header.website-header {
   padding: 40px 60px;
 }
 
-// edmc logo
+// ontology logo
 .navbar-brand {
   padding: 0;
   margin: 0;
 
-  #logo-fibo {
+  #ontology-logo {
     width: 140px;
-    height: 40px;
+    max-height: 100px;
+    object-fit: contain;
+    object-position: left;
   }
 }
 
@@ -415,13 +416,12 @@ header.website-header {
 @media (max-width: 430px) {
   header.website-header {
     min-height: 520px;
-    max-height: 520px;
   }
 }
 
 @media (max-width: 991px) {
   .navbar-brand {
-    #logo-fibo {
+    #ontology-logo {
       width: 105px;
     }
   }
@@ -461,7 +461,6 @@ header.website-header {
 @media (max-width: 992px) and (min-width: 700px) {
   header.website-header {
     min-height: 400px;
-    max-height: 400px;
   }
 }
 

--- a/general/components/SlideCarousel.vue
+++ b/general/components/SlideCarousel.vue
@@ -97,6 +97,9 @@ export default {
   display: flex;
   flex-direction: column;
 
+  min-height: 340px;
+  max-height: 340px;
+
   #carouselController {
     flex: 1;
     display: flex;
@@ -267,6 +270,10 @@ export default {
 }
 
 @media (max-width: 350px) {
+  .carousel-container {
+    min-height: 380px;
+    max-height: 380px;
+  }
   .carousel-item {
     .text-display {
       font-size: 30px;
@@ -286,9 +293,20 @@ export default {
 }
 
 @media (max-width: 991px) {
+  .carousel-container {
+    min-height: 380px;
+    max-height: 380px;
+  }
   .carousel-container .carousel-inner {
     display: flex;
     align-items: flex-start;
+  }
+}
+
+@media (max-width: 992px) and (min-width: 700px) {
+  .carousel-container {
+    min-height: 260px;
+    max-height: 260px;
   }
 }
 


### PR DESCRIPTION
closes: #330 

Changes:

- Logo will always keep it's original ratio
- The header section will scale up based on navigation bar (which contains logo) size
- The carousel section will always keep the same size
- Maximum height of a logo is set to 100px, maximum width is 140px. So a square logo would take up to 100x100px
- Custom logo link is set to a relative path "/"

Additionally, some legacy element ID names referencing FIBO were changed in code to be more general.

Example (for visual presentation purpose only):

![image](https://user-images.githubusercontent.com/87621210/216323001-13789602-695d-4ee1-acde-4e07eade94ad.png)

