### PR TITLE
Wrong version selected when refreshing page

### DIFF
--- a/general/store/servers.js
+++ b/general/store/servers.js
@@ -45,6 +45,7 @@ export default {
     async updateServers({ commit, state, rootState }, { route, to }) {
       let internalRoute = route;
       let ontoviewerDefaultDomain = rootState.configuration.ontoviewerServerUrl;
+      let version = null;
 
       if (to !== undefined) {
         internalRoute = to;
@@ -80,7 +81,6 @@ export default {
       let missingImportsServer = ontoviewerDefaultDomain + state.missingImportsSegment;
       let modulesServer = ontoviewerDefaultDomain + state.modulesSegment;
       let graphServer = ontoviewerDefaultDomain + state.graphSegment;
-      let version = null;
 
       commit("SET_VERSION", { version });
       commit("SET_SEARCH_SERVER", { searchServer });


### PR DESCRIPTION
closes: #332 
The feature should work properly now.
Temporary `version` variable was declared in the wrong place in `servers.js` store.