### PR TITLE
Handle new version IRI in entity response

### DIFF
--- a/general/pages/_.vue
+++ b/general/pages/_.vue
@@ -832,35 +832,18 @@
                           </div>
                           <h6
                             class="card-subtitle data-iri"
-                            v-if="
-                              this.$route.query &&
-                              this.$route.query.version &&
-                              data.iri &&
-                              data.iri.startsWith(uriSpace)
-                            "
+                            v-if="data.versionIri"
                           >
                             {{
-                              this.uriSpace +
-                              this.$route.query.version +
-                              "/" +
-                              data.iri.replace(this.uriSpace, "")
+                              data.versionIri
                             }}
                           </h6>
                           <div
                             class="url-buttons-container"
-                            v-if="
-                              this.$route.query &&
-                              this.$route.query.version &&
-                              data.iri.startsWith(uriSpace)
-                            "
+                            v-if="data.versionIri"
                           >
                             <CopyButton
-                              :copyContent="
-                                this.uriSpace +
-                                this.$route.query.version +
-                                '/' +
-                                data.iri.replace(this.uriSpace, '')
-                              "
+                              :copyContent="data.versionIri"
                               :text="'Copy versioned IRI'"
                               class="btn-copy-iri"
                             />


### PR DESCRIPTION
closes: #341 

The frontend will now always display versioned IRI if it's available in the entity endpoint response.

![image](https://user-images.githubusercontent.com/87621210/220870790-3f317f0e-bc51-4b22-b18d-4b7b348a3472.png)
