### PR TITLE
Promote master/latest in the TM instances list

### DIFF
--- a/general/components/Articles/SerializationListSection.vue
+++ b/general/components/Articles/SerializationListSection.vue
@@ -246,6 +246,10 @@ export default {
           `/${this.ontologyName}/ontology/`
         );
         const ontologyVersions = await result.json();
+
+        const first = "master/latest";
+        ontologyVersions.sort((x,y) => { return x['@id'] == first ? -1 : y['@id'] == first ? 1 : 0; });
+
         this.ontologyVersionsDropdownData.data = ontologyVersions;
 
         if (this.version !== null) {

--- a/general/pages/_.vue
+++ b/general/pages/_.vue
@@ -842,6 +842,10 @@ export default {
           `/${this.ontologyName}/ontology/api/`
         );
         const ontologyVersions = await result.json();
+
+        const first = "master/latest";
+        ontologyVersions.sort((x,y) => { return x['@id'] == first ? -1 : y['@id'] == first ? 1 : 0; });
+
         this.ontologyVersionsDropdownData.data = ontologyVersions;
         ontologyVersions.unshift(this.ontologyVersionsDropdownData.defaultData); // add default at the beginning
 


### PR DESCRIPTION
closes: #356 

With this change "master/latest" should always appear first on the instances list.