### PR TITLE
Initial font size in onto-viewer diagrams

### DIFF
--- a/general/components/Ontology/DescribeButton.vue
+++ b/general/components/Ontology/DescribeButton.vue
@@ -182,13 +182,6 @@ export default {
         this.copied = false;
       }, 1500);
     },
-    clipboardSuccessHandler ({ value, event }) {
-      console.log('success', value)
-    },
-
-    clipboardErrorHandler ({ value, event }) {
-      console.log('error', value)
-    }
   },
   computed: {
     ...mapState({


### PR DESCRIPTION
closes: #362 

Changes:
- The minimalized diagram section will now be centered and zoomed by default.
- Initial node distance reduced to 30.
- When scrolling over the visualization, an overlay will appear informing that the user can zoom by holding CTRL/command + scroll.
- Changed the layout of minimalized diagram section.
- The app will now remember node `Node distance` and `Display all edge labels` options set by user in the Control Panel

---
## Minimalized diagram section changes:

Layouts were removed from the minimalized view and are available only in full screen mode. Height of the visualization was increased. Download button was moved to the top right, next to the user guide.

![image](https://user-images.githubusercontent.com/87621210/236796009-6704b5e4-8c8b-4e56-9709-c09fb94e9ae9.png)

---
## Overlay that appears when user is scrolling over diagram:

![image](https://user-images.githubusercontent.com/87621210/236796474-5ee4848d-d5e5-4c30-aff4-e136e2656dea.png)


