### PR TITLE
Version selection for products

### DIFF
--- a/general/components/Articles/SerializationListSection.vue
+++ b/general/components/Articles/SerializationListSection.vue
@@ -252,7 +252,7 @@ export default {
     async fetchVersions() {
       try {
         const result = await getOntologyVersions(
-          `/${this.ontologyName}/ontology/`,
+          `/${this.ontologyName}/ontology/api/`,
         );
         const ontologyVersions = await result.json();
 


### PR DESCRIPTION
closes: #434 

Products version list will now use a different endpoint to fetch versions.