### PR TITLE
Two dots in mobile version of onto-viewer

### DIFF
--- a/general/components/Resource/ResourceSection.vue
+++ b/general/components/Resource/ResourceSection.vue
@@ -392,10 +392,6 @@ export default {
         }
 
         & > li {
-          background: url("@/assets/icons/dot.svg") no-repeat 0px 0px;
-          list-style: none;
-          padding: 0px 0px 0px 30px;
-
           ul {
             padding-left: 20px;
           }


### PR DESCRIPTION
closes: #448 

The bug is fixed:
![image](https://github.com/edmcouncil/html-pages/assets/87621210/93c86f0d-bd10-4a77-95cd-e33bc6666ec9)
