### PR TITLE
Inferrable restriction as a warning

### DIFF
--- a/general/assets/icons/tooltip-warn.svg
+++ b/general/assets/icons/tooltip-warn.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12ZM11 5C11 4.44771 11.4477 4 12 4C12.5523 4 13 4.44772 13 5V14C13 14.5523 12.5523 15 12 15C11.4477 15 11 14.5523 11 14V5ZM13 19V17H11V19H13Z" fill="#feb700" fill-opacity="1"/>
+</svg>

--- a/general/components/Ontology/TooltipInline.vue
+++ b/general/components/Ontology/TooltipInline.vue
@@ -1,6 +1,10 @@
 <template>
   <bs-tooltip :text="text" :variant="variant">
-    <div ref="resourceInlineTooltip" class="resource-inline-tooltip"></div>
+    <div
+      ref="resourceInlineTooltip"
+      class="resource-inline-tooltip"
+      :class="{ warn: variant === 'warning' }"
+    ></div>
   </bs-tooltip>
 </template>
 
@@ -31,5 +35,10 @@ export default defineComponent({
   opacity: 0.5;
   margin-left: 5px;
   margin-right: 5px;
+
+  &.warn {
+    background-image: url('../../assets/icons/tooltip-warn.svg');
+    opacity: 1;
+  }
 }
 </style>

--- a/general/components/Ontology/TooltipInline.vue
+++ b/general/components/Ontology/TooltipInline.vue
@@ -1,14 +1,23 @@
 <template>
-  <bs-tooltip :text="text">
+  <bs-tooltip :text="text" :variant="variant">
     <div ref="resourceInlineTooltip" class="resource-inline-tooltip"></div>
   </bs-tooltip>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+export default defineComponent({
   name: 'TooltipInline',
-  props: ['text']
-};
+  props: {
+    text: {
+      type: String,
+      required: true
+    },
+    variant: {
+      type: String as PropType<'default' | 'warning'>,
+      default: 'default'
+    }
+  }
+});
 </script>
 
 <style lang="scss">

--- a/general/components/Resource/chunks/AXIOM.vue
+++ b/general/components/Resource/chunks/AXIOM.vue
@@ -4,7 +4,11 @@
       <component :is="processedTitle"></component>
     </span>
 
-    <TooltipInline v-if="inferable" :text="tooltips.inferable" />
+    <TooltipInline
+      v-if="inferable"
+      :text="tooltips.inferable"
+      :variant="'warning'"
+    />
     <ul v-if="processedList.length > 0">
       <li
         v-for="(item, index) in processedList"
@@ -19,7 +23,11 @@
       <component :is="processedTitle"></component>
     </span>
 
-    <TooltipInline v-if="inferable" :text="tooltips.inferable" />
+    <TooltipInline
+      v-if="inferable"
+      :text="tooltips.inferable"
+      :variant="'warning'"
+    />
     <ul>
       <li
         v-for="(item, index) in processedListSlice"

--- a/general/components/UI/bs-tooltip.vue
+++ b/general/components/UI/bs-tooltip.vue
@@ -2,8 +2,8 @@
   <div
     ref="tooltipElement"
     :data-bs-title="text"
-    :data-bs-placement="placement ? placement : 'bottom'"
-    :data-bs-offset="offset ? offset : '0,0'"
+    :data-bs-placement="placement"
+    :data-bs-offset="offset"
     class="bs-tooltip"
     data-bs-toggle="tooltip"
   >
@@ -11,24 +11,52 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
   name: 'BsTooltip',
-  props: ['text', 'placement', 'offset'],
+  props: {
+    text: {
+      type: String,
+      required: true
+    },
+    placement: {
+      type: String as PropType<'auto' | 'top' | 'bottom' | 'left' | 'right'>,
+      default: 'bottom'
+    },
+    offset: {
+      type: String,
+      default: '0,0'
+    },
+    variant: {
+      type: String as PropType<'default' | 'warning'>,
+      default: 'default'
+    }
+  },
   data() {
     return {
-      instance: null
+      instance: null as any
     };
   },
   mounted() {
     const { $bootstrap } = useNuxtApp();
-    const element = this.$refs.tooltipElement;
-    this.instance = new $bootstrap.Tooltip(element);
+    const element = this.$refs.tooltipElement as HTMLElement;
+    if (element) {
+      this.instance = new $bootstrap.Tooltip(element, {
+        title: this.text,
+        placement: this.placement,
+        offset: this.offset,
+        customClass: this.variant
+      });
+    }
   },
   beforeUnmount() {
-    this.instance.dispose();
+    if (this.instance) {
+      this.instance.dispose();
+    }
   }
-};
+});
 </script>
 
 <style lang="scss">
@@ -47,5 +75,15 @@ export default {
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   font-family: Inter;
+
+  &.warning {
+    --bs-tooltip-bg: #feb700;
+    --bs-tooltip-color: black;
+  }
+
+  &.default {
+    --bs-tooltip-bg: black;
+    --bs-tooltip-color: var(--bs-body-bg);
+  }
 }
 </style>

--- a/general/plugins/use-bootstrap.client.ts
+++ b/general/plugins/use-bootstrap.client.ts
@@ -1,5 +1,9 @@
 import * as bootstrap from 'bootstrap';
 
-export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.provide('bootstrap', bootstrap);
+export default defineNuxtPlugin(() => {
+  return {
+    provide: {
+      bootstrap
+    }
+  };
 });


### PR DESCRIPTION
Added `variant` property which can be set to `default` or `warning` in the tooltip component.
Inferable tooltip will now show as warning:

![image](https://github.com/edmcouncil/html-pages/assets/87621210/3145dcd0-3988-41d7-a580-f557311e6b6d)
