### PR TITLE
Different display of bNodes

### DIFF
--- a/general/components/Ontology/TooltipText.vue
+++ b/general/components/Ontology/TooltipText.vue
@@ -1,17 +1,10 @@
 <template>
   <span v-if="found"
-    ><!--
-  -->{{ textBefore
-    }}<!--
-    --><bs-tooltip :text="tooltipText"
-      ><!--
-      --><span class="resource-text-tooltip">{{ textWrapped }}</span
-      ><!--
-    --></bs-tooltip
-    ><!--
-    -->{{ textAfter
-    }}<!--
-  --></span>
+    >{{ textBefore
+    }}<bs-tooltip :text="tooltipText" offset="0,10"
+      ><span class="resource-text-tooltip">{{ textWrapped }}</span></bs-tooltip
+    >{{ textAfter }}</span
+  >
   <span v-else>
     {{ content }}
   </span>

--- a/general/components/Resource/ResourceHeader.vue
+++ b/general/components/Resource/ResourceHeader.vue
@@ -88,7 +88,7 @@
         <div v-if="isBNode" class="blank-node-alert" role="alert">
           <div class="blank-node-icon"></div>
           <div class="description">
-            This is blank node, which does not have an IRI.
+            This is a blank node, which does not have an IRI.
             <a href="https://www.w3.org/wiki/BlankNodes" target="_blank">
               Learn more
             </a>

--- a/general/components/Resource/ResourceHeader.vue
+++ b/general/components/Resource/ResourceHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="col-md-12 ontology-item__header">
+  <div class="ontology-item__header">
     <div class="card">
       <div class="card-body">
         <div class="ontology-item__header__title-segment">
@@ -85,6 +85,16 @@
           </div>
         </div>
 
+        <div v-if="isBNode" class="blank-node-alert" role="alert">
+          <div class="blank-node-icon"></div>
+          <div class="description">
+            This is blank node, which does not have an IRI.
+            <a href="https://www.w3.org/wiki/BlankNodes" target="_blank">
+              Learn more
+            </a>
+          </div>
+        </div>
+
         <h6 v-if="data.iri" class="card-subtitle data-iri">
           {{ data.iri }}
         </h6>
@@ -121,6 +131,7 @@
 <script>
 import { mapState } from 'pinia';
 import { useConfigurationStore } from '@/stores/configuration';
+import { isResourceBNode } from '~/helpers/ontology';
 
 export default {
   name: 'ResourceHeader',
@@ -154,6 +165,9 @@ export default {
         this.data.maturityLevel.label === 'Provisional' ||
         this.data.maturityLevel.label === 'Preliminary'
       );
+    },
+    isBNode() {
+      return isResourceBNode(this.data.iri);
     }
   },
   methods: {
@@ -184,6 +198,54 @@ export default {
   margin-bottom: 60px;
   margin-top: 40px;
   padding: 0;
+
+  .blank-node-alert {
+    position: relative;
+    margin-top: 0;
+    margin-bottom: 20px;
+    border-radius: 2px;
+    padding: 15px 15px 15px 15px;
+    width: fit-content;
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    background-color: #feb700;
+
+    .description {
+      z-index: 1;
+    }
+
+    .blank-node-icon {
+      width: 24px;
+      height: 24px;
+      background-image: url('../../assets/icons/warning.svg');
+      display: inline-block;
+      z-index: 1;
+      margin-right: 10px;
+      flex-shrink: 0;
+    }
+
+    a {
+      text-decoration: underline;
+    }
+
+    &::before {
+      content: '';
+      display: block;
+      height: 20px;
+      width: 20px;
+      background-color: inherit;
+      border: inherit;
+      position: absolute;
+      bottom: -3px;
+      left: 4px;
+      clip-path: polygon(0% 0%, 100% 100%, 0% 100%);
+      transform: rotate(-45deg);
+      border-radius: 2px;
+    }
+  }
 
   .ontology-item__header__title-segment {
     display: flex;
@@ -400,6 +462,7 @@ export default {
   }
 
   h2 {
+    word-break: break-word;
     font-style: normal;
     font-weight: bold;
     font-size: 42px;
@@ -603,6 +666,19 @@ export default {
 
     .card {
       background: none;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .blank-node-alert .description {
+    margin-left: 15px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+
+    a {
+      align-self: flex-end;
     }
   }
 }

--- a/general/components/Resource/ResourceHeader.vue
+++ b/general/components/Resource/ResourceHeader.vue
@@ -204,7 +204,7 @@ export default {
     margin-top: 0;
     margin-bottom: 20px;
     border-radius: 2px;
-    padding: 15px 15px 15px 15px;
+    padding: 10px 15px;
     width: fit-content;
 
     display: flex;

--- a/general/components/Resource/chunks/customLink.vue
+++ b/general/components/Resource/chunks/customLink.vue
@@ -12,8 +12,12 @@
     }"
     :class="{ deprecated: isDeprecated === 'true' }"
     @click.native="linkClickNative"
-    >{{ name
-    }}<TooltipInline
+    ><TooltipText
+      v-if="isBNode"
+      :tooltip-text="'This is a Blank Node'"
+      :content="name"
+      :defining="name" /><span v-else>{{ name }}</span
+    ><TooltipInline
       v-if="isDeprecated === 'true'"
       :text="tooltips['deprecated']"
   /></nuxt-link>
@@ -30,8 +34,12 @@
       }
     }"
     :class="{ deprecated: isDeprecated === 'true' }"
-    >{{ name
-    }}<TooltipInline
+    ><TooltipText
+      v-if="isBNode"
+      :tooltip-text="tooltips['bnode']"
+      :content="name"
+      :defining="name" /><span v-else>{{ name }}</span
+    ><TooltipInline
       v-if="isDeprecated === 'true'"
       :text="tooltips['deprecated']"
   /></nuxt-link>
@@ -41,6 +49,7 @@
 import { mapState } from 'pinia';
 import { useConfigurationStore } from '@/stores/configuration';
 import tooltips from '~/constants/tooltips';
+import { isResourceBNode } from '~/helpers/ontology';
 
 export default {
   name: 'CustomLink',
@@ -61,7 +70,10 @@ export default {
   computed: {
     ...mapState(useConfigurationStore, {
       uriSpace: (store) => store.config.uriSpace
-    })
+    }),
+    isBNode() {
+      return isResourceBNode(this.query);
+    }
   },
   methods: {
     linkClickNative(event) {

--- a/general/constants/tooltips.js
+++ b/general/constants/tooltips.js
@@ -6,5 +6,6 @@ export default {
     'A resource is internal to an ontology if it is defined in this ontology.',
   'external':
     'A resource is external to an ontology if it is defined outside of this ontology.',
-  'inferable': 'This restriction is inferable from other restrictions.'
+  'inferable': 'This restriction is inferable from other restrictions.',
+  'bnode': 'This is a Blank Node.'
 };

--- a/general/helpers/ontology.ts
+++ b/general/helpers/ontology.ts
@@ -1,9 +1,10 @@
+import type { Data } from './compare.types';
 import { prepareDescription } from './meta';
 
-export function generateTitleAndDescription(body) {
+export function generateTitleAndDescription(body: { result: Data }) {
   let title = null;
   let description = null;
-  if (body.result.properties.Glossary) {
+  if (body?.result?.properties?.Glossary) {
     // check is title or label exist and set it to title page
     if (
       body.result.properties.Glossary.title &&
@@ -37,12 +38,10 @@ export function generateTitleAndDescription(body) {
   return { title, description };
 }
 
-export function handleDeprecatedResource(body) {
+export function handleDeprecatedResource(body: { result: Data }) {
   if (
-    body.result.properties['Ontological characteristic'] &&
-    body.result.properties['Ontological characteristic'].deprecated &&
-    body.result.properties['Ontological characteristic'].deprecated[0].value ===
-      'true'
+    body.result.properties?.['Ontological characteristic']?.deprecated?.[0]
+      ?.value === 'true'
   ) {
     body.result.deprecated = true;
     delete body.result.properties['Ontological characteristic'].deprecated;
@@ -55,4 +54,8 @@ export function handleDeprecatedResource(body) {
   } else {
     body.result.deprecated = false;
   }
+}
+
+export function isResourceBNode(iri: string) {
+  return iri.startsWith('_:');
 }


### PR DESCRIPTION
When browsing resource, bnodes will be underlined with dashed line to indicate tooltip information. The tooltip contains information about blank node:

![image](https://github.com/edmcouncil/html-pages/assets/87621210/8a7a4f75-ab03-4a29-8d4e-eaafbc456251)

Resources that are blank nodes will have an alert about IRI and link to read more about blank nodes.

![image](https://github.com/edmcouncil/html-pages/assets/87621210/63777118-643a-4653-9fc8-e4935a185dae)
