### PR TITLE
Fix docker build process failing

### DIFF
--- a/general/pages/release-notes.vue
+++ b/general/pages/release-notes.vue
@@ -117,7 +117,7 @@ export default {
         // error({ statusCode: 503, message: 'Service Unavailable' });
       }
 
-      const responseData = response.data.value.data;
+      const responseData = response?.data?.value?.data || [];
       const releaseTree = new Map();
       const releaseList = [];
       for (const releaseItem of responseData) {


### PR DESCRIPTION
Making release notes data optional will fix docker image not building properly on `nuxt 3.12`.