### PR TITLE
Show version selection when there is one version in the list

### DIFF
--- a/general/pages/ontology/[...resource].vue
+++ b/general/pages/ontology/[...resource].vue
@@ -987,7 +987,7 @@ export default {
       );
     },
     hasVersions() {
-      return this.ontologyVersions.data.length > 1;
+      return this.ontologyVersions.data.length >= 1;
     },
     isComparing() {
       return (


### PR DESCRIPTION
Updated the `hasVersions` condition to show version selection when there is one version in the list to select from.